### PR TITLE
Sitemap discovery and filtering fixups

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -109,16 +109,16 @@ afdocs check https://docs.example.com --max-links 100
 
 ### URL discovery
 
-| Flag                  | Default     | Description                                                      |
-| --------------------- | ----------- | ---------------------------------------------------------------- |
-| `--locale <code>`     | auto-detect | Preferred locale for URL discovery (e.g. `en`, `fr`, `ja`)       |
-| `--version <version>` | auto-detect | Preferred version for URL discovery (e.g. `v3`, `2.x`, `latest`) |
+| Flag                      | Default     | Description                                                      |
+| ------------------------- | ----------- | ---------------------------------------------------------------- |
+| `--doc-locale <code>`     | auto-detect | Preferred locale for URL discovery (e.g. `en`, `fr`, `ja`)       |
+| `--doc-version <version>` | auto-detect | Preferred version for URL discovery (e.g. `v3`, `2.x`, `latest`) |
 
 When `afdocs` discovers pages from a sitemap or `llms.txt`, it automatically filters out duplicate locale and version variants so you get a representative sample of unique content.
 
 The resolution order for both flags is:
 
-1. **Explicit flag** (`--locale`, `--version`) if provided
+1. **Explicit flag** (`--doc-locale`, `--doc-version`) if provided
 2. **Auto-detect** from the base URL path (e.g. `https://docs.example.com/fr/v3` detects `fr` and `v3`)
 3. **Built-in fallback** when neither of the above yields a value: locale falls back to `en`; version prefers unversioned URLs, then `latest`/`stable`/`current`, then the highest semver
 
@@ -126,13 +126,13 @@ Use the flags when the base URL doesn't contain locale or version segments but t
 
 ```bash
 # Prefer French locale during discovery
-afdocs check https://docs.example.com --locale fr
+afdocs check https://docs.example.com --doc-locale fr
 
 # Prefer a specific version
-afdocs check https://docs.example.com --version v3
+afdocs check https://docs.example.com --doc-version v3
 
 # Both together
-afdocs check https://docs.example.com --locale ja --version 2.x
+afdocs check https://docs.example.com --doc-locale ja --doc-version 2.x
 ```
 
 ### Request behavior

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -107,6 +107,34 @@ afdocs check https://docs.example.com --max-links 10
 afdocs check https://docs.example.com --max-links 100
 ```
 
+### URL discovery
+
+| Flag                  | Default     | Description                                                      |
+| --------------------- | ----------- | ---------------------------------------------------------------- |
+| `--locale <code>`     | auto-detect | Preferred locale for URL discovery (e.g. `en`, `fr`, `ja`)       |
+| `--version <version>` | auto-detect | Preferred version for URL discovery (e.g. `v3`, `2.x`, `latest`) |
+
+When `afdocs` discovers pages from a sitemap or `llms.txt`, it automatically filters out duplicate locale and version variants so you get a representative sample of unique content.
+
+The resolution order for both flags is:
+
+1. **Explicit flag** (`--locale`, `--version`) if provided
+2. **Auto-detect** from the base URL path (e.g. `https://docs.example.com/fr/v3` detects `fr` and `v3`)
+3. **Built-in fallback** when neither of the above yields a value: locale falls back to `en`; version prefers unversioned URLs, then `latest`/`stable`/`current`, then the highest semver
+
+Use the flags when the base URL doesn't contain locale or version segments but the site organizes content by locale or version.
+
+```bash
+# Prefer French locale during discovery
+afdocs check https://docs.example.com --locale fr
+
+# Prefer a specific version
+afdocs check https://docs.example.com --version v3
+
+# Both together
+afdocs check https://docs.example.com --locale ja --version 2.x
+```
+
 ### Request behavior
 
 | Flag                    | Default | Description                            |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -120,7 +120,7 @@ The resolution order for both flags is:
 
 1. **Explicit flag** (`--doc-locale`, `--doc-version`) if provided
 2. **Auto-detect** from the base URL path (e.g. `https://docs.example.com/fr/v3` detects `fr` and `v3`)
-3. **Built-in fallback** when neither of the above yields a value: locale falls back to `en`; version prefers unversioned URLs, then `latest`/`stable`/`current`, then the highest semver
+3. **Built-in fallback** when neither of the above yields a value: locale falls back to `en`; version prefers unversioned URLs, then `latest`/`stable`/`current`, then the highest semver. Pre-release channels (`dev`, `next`, `nightly`, `canary`) are ranked below stable versions
 
 Use the flags when the base URL doesn't contain locale or version segments but the site organizes content by locale or version.
 

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -25,6 +25,8 @@ options:
   samplingStrategy: deterministic
   maxConcurrency: 5
   requestDelay: 100
+  preferredLocale: en
+  preferredVersion: v3
   thresholds:
     pass: 50000
     fail: 100000
@@ -52,15 +54,17 @@ This is particularly useful when your docs platform doesn't support certain capa
 
 Override default runner options. All fields are optional:
 
-| Field              | Default  | Description                                          |
-| ------------------ | -------- | ---------------------------------------------------- |
-| `maxLinksToTest`   | `50`     | Maximum number of pages to sample                    |
-| `samplingStrategy` | `random` | `random`, `deterministic`, `curated`, or `none`      |
-| `maxConcurrency`   | `3`      | Maximum concurrent HTTP requests                     |
-| `requestDelay`     | `200`    | Delay between requests in milliseconds               |
-| `requestTimeout`   | `30000`  | Timeout for individual HTTP requests in milliseconds |
-| `thresholds.pass`  | `50000`  | Page size pass threshold in characters               |
-| `thresholds.fail`  | `100000` | Page size fail threshold in characters               |
+| Field              | Default     | Description                                                |
+| ------------------ | ----------- | ---------------------------------------------------------- |
+| `maxLinksToTest`   | `50`        | Maximum number of pages to sample                          |
+| `samplingStrategy` | `random`    | `random`, `deterministic`, `curated`, or `none`            |
+| `maxConcurrency`   | `3`         | Maximum concurrent HTTP requests                           |
+| `requestDelay`     | `200`       | Delay between requests in milliseconds                     |
+| `requestTimeout`   | `30000`     | Timeout for individual HTTP requests in milliseconds       |
+| `preferredLocale`  | auto-detect | Preferred locale for URL discovery (e.g. `en`, `fr`, `ja`) |
+| `preferredVersion` | auto-detect | Preferred version for URL discovery (e.g. `v3`, `2.x`)     |
+| `thresholds.pass`  | `50000`     | Page size pass threshold in characters                     |
+| `thresholds.fail`  | `100000`    | Page size fail threshold in characters                     |
 
 ### `pages` (optional)
 

--- a/src/checks/observability/llms-txt-freshness.ts
+++ b/src/checks/observability/llms-txt-freshness.ts
@@ -261,6 +261,8 @@ async function check(ctx: CheckContext): Promise<CheckResult> {
     sitemapWarnings,
     MAX_FRESHNESS_SITEMAP_URLS,
     effectiveOrigin,
+    undefined,
+    true, // skip locale/version refinement — freshness does its own locale filtering
   );
   let sitemapSource = 'robots.txt/sitemap.xml';
   const baseUrlPath = new URL(ctx.baseUrl).pathname.replace(/\/$/, '');

--- a/src/checks/observability/llms-txt-freshness.ts
+++ b/src/checks/observability/llms-txt-freshness.ts
@@ -256,14 +256,11 @@ async function check(ctx: CheckContext): Promise<CheckResult> {
   //    sitemap URLs at the redirected host are accepted rather than filtered out.
   const effectiveOrigin = ctx.effectiveOrigin ?? ctx.origin;
   const sitemapWarnings: string[] = [];
-  let sitemapUrls = await getUrlsFromSitemap(
-    ctx,
-    sitemapWarnings,
-    MAX_FRESHNESS_SITEMAP_URLS,
-    effectiveOrigin,
-    undefined,
-    true, // skip locale/version refinement — freshness does its own locale filtering
-  );
+  let sitemapUrls = await getUrlsFromSitemap(ctx, sitemapWarnings, {
+    maxUrls: MAX_FRESHNESS_SITEMAP_URLS,
+    originOverride: effectiveOrigin,
+    skipRefinement: true,
+  });
   let sitemapSource = 'robots.txt/sitemap.xml';
   const baseUrlPath = new URL(ctx.baseUrl).pathname.replace(/\/$/, '');
 

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -30,6 +30,8 @@ export function registerCheckCommand(program: Command): void {
       '--urls <urls>',
       'Comma-separated page URLs for curated scoring (implies --sampling curated)',
     )
+    .option('--locale <code>', 'Preferred locale for URL discovery (e.g. en, fr, ja)')
+    .option('--version <version>', 'Preferred version for URL discovery (e.g. v3, 2.x, latest)')
     .option('--pass-threshold <n>', 'Pass threshold in characters')
     .option('--fail-threshold <n>', 'Fail threshold in characters')
     .option('-v, --verbose', 'Show per-page details for checks with issues')
@@ -163,6 +165,11 @@ export function registerCheckCommand(program: Command): void {
         process.stderr.write(`Running checks on ${target}...\n`);
       }
 
+      const preferredLocale =
+        (opts.locale as string | undefined) ?? config?.options?.preferredLocale;
+      const preferredVersion =
+        (opts.version as string | undefined) ?? config?.options?.preferredVersion;
+
       const report = await runChecks(url, {
         checkIds,
         maxConcurrency,
@@ -174,6 +181,8 @@ export function registerCheckCommand(program: Command): void {
           pass: passThreshold,
           fail: failThreshold,
         },
+        ...(preferredLocale && { preferredLocale }),
+        ...(preferredVersion && { preferredVersion }),
       });
 
       let output: string;

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -30,8 +30,8 @@ export function registerCheckCommand(program: Command): void {
       '--urls <urls>',
       'Comma-separated page URLs for curated scoring (implies --sampling curated)',
     )
-    .option('--locale <code>', 'Preferred locale for URL discovery (e.g. en, fr, ja)')
-    .option('--version <version>', 'Preferred version for URL discovery (e.g. v3, 2.x, latest)')
+    .option('--doc-locale <code>', 'Preferred locale for URL discovery (e.g. en, fr, ja)')
+    .option('--doc-version <version>', 'Preferred version for URL discovery (e.g. v3, 2.x, latest)')
     .option('--pass-threshold <n>', 'Pass threshold in characters')
     .option('--fail-threshold <n>', 'Fail threshold in characters')
     .option('-v, --verbose', 'Show per-page details for checks with issues')
@@ -166,9 +166,9 @@ export function registerCheckCommand(program: Command): void {
       }
 
       const preferredLocale =
-        (opts.locale as string | undefined) ?? config?.options?.preferredLocale;
+        (opts.docLocale as string | undefined) ?? config?.options?.preferredLocale;
       const preferredVersion =
-        (opts.version as string | undefined) ?? config?.options?.preferredVersion;
+        (opts.docVersion as string | undefined) ?? config?.options?.preferredVersion;
 
       const report = await runChecks(url, {
         checkIds,

--- a/src/helpers/get-page-urls.ts
+++ b/src/helpers/get-page-urls.ts
@@ -223,8 +223,19 @@ async function discoverSitemapUrls(ctx: CheckContext, originOverride?: string): 
     }
   }
 
-  // Default to /sitemap.xml (prefer effective origin if available)
-  return [`${originOverride ?? ctx.origin}/sitemap.xml`];
+  // Build fallback candidates: origin-level sitemap first, then subpath sitemaps
+  // when the base URL has a non-root path (e.g. swagger.io/docs/).
+  const fallbackOrigin = originOverride ?? ctx.origin;
+  const candidates = [`${fallbackOrigin}/sitemap.xml`];
+
+  const baseUrlPath = new URL(ctx.baseUrl).pathname.replace(/\/$/, '');
+  if (baseUrlPath && baseUrlPath !== '') {
+    const subpathBase = `${fallbackOrigin}${baseUrlPath}`;
+    candidates.push(`${subpathBase}/sitemap.xml`);
+    candidates.push(`${subpathBase}/sitemap-index.xml`);
+  }
+
+  return candidates;
 }
 
 export interface PageUrlResult {

--- a/src/helpers/get-page-urls.ts
+++ b/src/helpers/get-page-urls.ts
@@ -600,7 +600,7 @@ export async function getUrlsFromSitemap(
     if (parsed.sitemapIndexUrls.length > 0 && urls.length < maxUrls) {
       const filteredSubSitemaps = filterLocaleSitemaps(
         parsed.sitemapIndexUrls,
-        extractLocaleFromUrl(ctx.baseUrl),
+        ctx.options.preferredLocale ?? extractLocaleFromUrl(ctx.baseUrl),
       );
       for (const subSitemapUrl of filteredSubSitemaps) {
         if (urls.length >= maxUrls) break;
@@ -617,8 +617,14 @@ export async function getUrlsFromSitemap(
     }
   }
 
-  const localeFiltered = filterLocalizedUrls(urls, extractLocaleFromUrl(ctx.baseUrl));
-  return deduplicateVersionedUrls(localeFiltered, extractVersionFromUrl(ctx.baseUrl));
+  const localeFiltered = filterLocalizedUrls(
+    urls,
+    ctx.options.preferredLocale ?? extractLocaleFromUrl(ctx.baseUrl),
+  );
+  return deduplicateVersionedUrls(
+    localeFiltered,
+    ctx.options.preferredVersion ?? extractVersionFromUrl(ctx.baseUrl),
+  );
 }
 
 /**
@@ -681,13 +687,13 @@ export async function getPageUrls(ctx: CheckContext): Promise<PageUrlResult> {
   const warnings: string[] = [];
 
   const filterBase = getPathFilterBase(ctx);
-  const baseLocale = extractLocaleFromUrl(ctx.baseUrl);
-  const baseVersion = extractVersionFromUrl(ctx.baseUrl);
+  const locale = ctx.options.preferredLocale ?? extractLocaleFromUrl(ctx.baseUrl);
+  const version = ctx.options.preferredVersion ?? extractVersionFromUrl(ctx.baseUrl);
 
   /** Apply locale and version filtering to a discovered URL set. */
   function refineUrls(urls: string[]): string[] {
-    const localeFiltered = filterLocalizedUrls(urls, baseLocale);
-    return deduplicateVersionedUrls(localeFiltered, baseVersion);
+    const localeFiltered = filterLocalizedUrls(urls, locale);
+    return deduplicateVersionedUrls(localeFiltered, version);
   }
 
   // 1. Try llms.txt links from cached results (if llms-txt-exists ran)

--- a/src/helpers/get-page-urls.ts
+++ b/src/helpers/get-page-urls.ts
@@ -261,26 +261,37 @@ export async function getUrlsFromSitemap(
   warnings: string[],
   maxUrls: number = MAX_SITEMAP_URLS,
   originOverride?: string,
+  pathFilterBase?: string,
 ): Promise<string[]> {
   const sitemapUrls = await discoverSitemapUrls(ctx, originOverride);
   const urls: string[] = [];
   const matchOrigin = originOverride ?? ctx.origin;
+
+  // Pre-compute the path prefix so we can filter before counting against the cap.
+  // When pathFilterBase is provided, only URLs under that prefix consume cap slots.
+  const prefixPath = pathFilterBase ? new URL(pathFilterBase).pathname.replace(/\/$/, '') : '';
+
+  function shouldInclude(url: string): boolean {
+    try {
+      const u = new URL(url);
+      if (u.origin !== matchOrigin) return false;
+      if (prefixPath) return matchesPathPrefix(url, prefixPath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
 
   for (const sitemapUrl of sitemapUrls) {
     if (urls.length >= maxUrls) break;
 
     const parsed = await fetchSitemap(ctx, sitemapUrl, warnings);
 
-    // Add direct URLs (filtered to same origin)
+    // Add direct URLs (filtered to same origin and path prefix)
     for (const url of parsed.urls) {
       if (urls.length >= maxUrls) break;
-      try {
-        const u = new URL(url);
-        if (u.origin === matchOrigin) {
-          urls.push(url);
-        }
-      } catch {
-        // Skip malformed URLs
+      if (shouldInclude(url)) {
+        urls.push(url);
       }
     }
 
@@ -293,13 +304,8 @@ export async function getUrlsFromSitemap(
 
         for (const url of subParsed.urls) {
           if (urls.length >= maxUrls) break;
-          try {
-            const u = new URL(url);
-            if (u.origin === matchOrigin) {
-              urls.push(url);
-            }
-          } catch {
-            // Skip malformed URLs
+          if (shouldInclude(url)) {
+            urls.push(url);
           }
         }
       }
@@ -323,6 +329,23 @@ export function getPathFilterBase(ctx: CheckContext): string {
 }
 
 /**
+ * Check whether a single URL falls under the given path prefix.
+ *
+ * Returns true when the baseUrl is at the root (no filtering needed),
+ * when the URL matches the prefix, or when the URL is malformed
+ * (kept rather than silently dropped).
+ */
+export function matchesPathPrefix(url: string, baseUrlPath: string): boolean {
+  if (!baseUrlPath || baseUrlPath === '') return true;
+  try {
+    const parsed = new URL(url);
+    return parsed.pathname === baseUrlPath || parsed.pathname.startsWith(baseUrlPath + '/');
+  } catch {
+    return true; // keep malformed URLs rather than silently dropping them
+  }
+}
+
+/**
  * Filter URLs to those under the baseUrl's path prefix.
  *
  * When the input URL has a non-root path (e.g. `https://plaid.com/docs`),
@@ -334,16 +357,7 @@ export function getPathFilterBase(ctx: CheckContext): string {
  */
 export function filterByPathPrefix(urls: string[], baseUrl: string): string[] {
   const baseUrlPath = new URL(baseUrl).pathname.replace(/\/$/, '');
-  if (!baseUrlPath || baseUrlPath === '') return urls;
-
-  return urls.filter((url) => {
-    try {
-      const parsed = new URL(url);
-      return parsed.pathname === baseUrlPath || parsed.pathname.startsWith(baseUrlPath + '/');
-    } catch {
-      return true; // keep malformed URLs rather than silently dropping them
-    }
-  });
+  return urls.filter((url) => matchesPathPrefix(url, baseUrlPath));
 }
 
 /**
@@ -374,10 +388,9 @@ export async function getPageUrls(ctx: CheckContext): Promise<PageUrlResult> {
     if (scopedFetchedUrls.length > 0) return { urls: scopedFetchedUrls, warnings };
   }
 
-  // 3. Try sitemap
-  const sitemapUrls = await getUrlsFromSitemap(ctx, warnings);
-  const scopedSitemapUrls = filterByPathPrefix(sitemapUrls, filterBase);
-  if (scopedSitemapUrls.length > 0) return { urls: scopedSitemapUrls, warnings };
+  // 3. Try sitemap (path filtering applied inside, before the URL cap)
+  const sitemapUrls = await getUrlsFromSitemap(ctx, warnings, undefined, undefined, filterBase);
+  if (sitemapUrls.length > 0) return { urls: sitemapUrls, warnings };
 
   // 4. Fallback
   return { urls: [ctx.baseUrl], warnings };

--- a/src/helpers/get-page-urls.ts
+++ b/src/helpers/get-page-urls.ts
@@ -384,7 +384,9 @@ export function filterLocalizedUrls(urls: string[], preferredLocale?: string | n
 /**
  * Version segment pattern: matches common versioning conventions in URL paths.
  *
- * Matches segments like: v2, v3.1, 2.x, 3.0.1, 1.8, latest, stable, current, dev, next
+ * Matches segments like: v2, v3.1, 2.x, 3.0.1, 1.8, latest, stable, current, dev, next.
+ * Pre-release channels (dev, next, nightly, canary) are recognized for grouping but
+ * ranked below stable versions during deduplication.
  * Does NOT match bare integers (e.g. `42`) since those are often page numbers or IDs.
  * Bare integers require a `v` prefix (e.g. `v2`) to be recognized as versions.
  */
@@ -527,11 +529,20 @@ export function deduplicateVersionedUrls(
       continue;
     }
 
-    // Pick the highest version by string sort (good enough for semver-ish)
-    const sorted = [...group].sort((a, b) =>
-      (b.version ?? '').localeCompare(a.version ?? '', undefined, { numeric: true }),
-    );
-    result.push(sorted[0].url);
+    // Pick the highest version by string sort, excluding pre-release channels
+    // (dev, next, nightly, canary) which should only win as a last resort.
+    const isPreRelease = (v: string | null) => /^(dev|next|nightly|canary)$/i.test(v ?? '');
+    const stable = group.filter((g) => !isPreRelease(g.version));
+
+    if (stable.length > 0) {
+      const sorted = [...stable].sort((a, b) =>
+        (b.version ?? '').localeCompare(a.version ?? '', undefined, { numeric: true }),
+      );
+      result.push(sorted[0].url);
+    } else {
+      // All variants are pre-release — pick the first one
+      result.push(group[0].url);
+    }
   }
 
   return result;
@@ -590,32 +601,37 @@ export async function getUrlsFromSitemap(
     }
   }
 
+  // Collect up to collectLimit URLs before refinement. The cap is applied
+  // *after* locale/version filtering so that deduplication can see the full
+  // version spectrum rather than an arbitrary prefix of the sitemap.
+  const collectLimit = skipRefinement ? maxUrls : maxUrls * 20;
+
   for (const sitemapUrl of sitemapUrls) {
-    if (urls.length >= maxUrls) break;
+    if (urls.length >= collectLimit) break;
 
     const parsed = await fetchSitemap(ctx, sitemapUrl, warnings);
 
     // Add direct URLs (filtered to same origin and path prefix)
     for (const url of parsed.urls) {
-      if (urls.length >= maxUrls) break;
+      if (urls.length >= collectLimit) break;
       if (shouldInclude(url)) {
         urls.push(url);
       }
     }
 
     // Follow one level of sitemap index, filtering to default locale if detected
-    if (parsed.sitemapIndexUrls.length > 0 && urls.length < maxUrls) {
+    if (parsed.sitemapIndexUrls.length > 0 && urls.length < collectLimit) {
       const filteredSubSitemaps = filterLocaleSitemaps(
         parsed.sitemapIndexUrls,
         ctx.options.preferredLocale ?? extractLocaleFromUrl(ctx.baseUrl),
       );
       for (const subSitemapUrl of filteredSubSitemaps) {
-        if (urls.length >= maxUrls) break;
+        if (urls.length >= collectLimit) break;
 
         const subParsed = await fetchSitemap(ctx, subSitemapUrl, warnings);
 
         for (const url of subParsed.urls) {
-          if (urls.length >= maxUrls) break;
+          if (urls.length >= collectLimit) break;
           if (shouldInclude(url)) {
             urls.push(url);
           }
@@ -630,10 +646,11 @@ export async function getUrlsFromSitemap(
     urls,
     ctx.options.preferredLocale ?? extractLocaleFromUrl(ctx.baseUrl),
   );
-  return deduplicateVersionedUrls(
+  const deduplicated = deduplicateVersionedUrls(
     localeFiltered,
     ctx.options.preferredVersion ?? extractVersionFromUrl(ctx.baseUrl),
   );
+  return deduplicated.slice(0, maxUrls);
 }
 
 /**

--- a/src/helpers/get-page-urls.ts
+++ b/src/helpers/get-page-urls.ts
@@ -248,8 +248,31 @@ function isGzipped(url: string): boolean {
 }
 
 /**
+ * Extract a locale-like segment from a URL path, if present.
+ * Matches 2-letter codes and xx-yy region subtags (e.g. `en`, `fr`, `pt-br`).
+ * Returns the locale string or null.
+ *
+ * Only returns a match when the segment is clearly positional (early in the path,
+ * before content segments), to avoid false positives on short path segments.
+ */
+export function extractLocaleFromUrl(url: string): string | null {
+  try {
+    const segments = new URL(url).pathname.split('/').filter(Boolean);
+    // Only check the first 3 segments to avoid matching content paths
+    for (let i = 0; i < Math.min(segments.length, 3); i++) {
+      if (/^[a-z]{2}(-[a-z]{2})?$/i.test(segments[i])) {
+        return segments[i].toLowerCase();
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+/**
  * Detect whether sub-sitemap URLs follow a locale naming convention and, if so,
- * filter to the default locale (preferring 'en').
+ * filter to the preferred locale. Defaults to 'en' when no preference is given.
  *
  * Common patterns:
  * - `sitemap-en.xml`, `sitemap-fr.xml`, `sitemap-el.xml`
@@ -257,7 +280,10 @@ function isGzipped(url: string): boolean {
  *
  * Returns the original array unchanged if no locale pattern is detected.
  */
-export function filterLocaleSitemaps(subSitemapUrls: string[]): string[] {
+export function filterLocaleSitemaps(
+  subSitemapUrls: string[],
+  preferredLocale?: string | null,
+): string[] {
   if (subSitemapUrls.length < 2) return subSitemapUrls;
 
   // Pattern 1: locale code in filename (sitemap-{locale}.xml)
@@ -285,8 +311,9 @@ export function filterLocaleSitemaps(subSitemapUrls: string[]): string[] {
   // Need at least 2 distinct locale codes to consider this a locale-organized index
   if (locales.size < 2) return subSitemapUrls;
 
-  // Prefer 'en', then any non-locale sitemaps
-  const preferred = locales.get('en') ?? [];
+  // Prefer the user's locale, then 'en', then any non-locale sitemaps
+  const locale = preferredLocale?.toLowerCase();
+  const preferred = (locale && locales.get(locale)) ?? locales.get('en') ?? [];
   return [...preferred, ...nonLocale].length > 0 ? [...preferred, ...nonLocale] : subSitemapUrls;
 }
 
@@ -507,7 +534,10 @@ export async function getUrlsFromSitemap(
 
     // Follow one level of sitemap index, filtering to default locale if detected
     if (parsed.sitemapIndexUrls.length > 0 && urls.length < maxUrls) {
-      const filteredSubSitemaps = filterLocaleSitemaps(parsed.sitemapIndexUrls);
+      const filteredSubSitemaps = filterLocaleSitemaps(
+        parsed.sitemapIndexUrls,
+        extractLocaleFromUrl(ctx.baseUrl),
+      );
       for (const subSitemapUrl of filteredSubSitemaps) {
         if (urls.length >= maxUrls) break;
 

--- a/src/helpers/get-page-urls.ts
+++ b/src/helpers/get-page-urls.ts
@@ -650,6 +650,48 @@ export function getPathFilterBase(ctx: CheckContext): string {
 }
 
 /**
+ * Rewrite the filter base URL when explicit locale/version preferences
+ * override values detected in the base URL path.
+ *
+ * For example, base URL `example.com/en/docs` with `--locale de` rewrites
+ * to `example.com/de/docs` so that path prefix filtering matches the
+ * preferred locale's URL space.
+ */
+function rewriteFilterBase(
+  filterBase: string,
+  preferredLocale?: string,
+  preferredVersion?: string,
+): string {
+  if (!preferredLocale && !preferredVersion) return filterBase;
+
+  try {
+    const url = new URL(filterBase);
+    const segments = url.pathname.split('/').filter(Boolean);
+
+    if (preferredLocale) {
+      const detected = extractLocaleFromUrl(filterBase);
+      if (detected && detected !== preferredLocale.toLowerCase()) {
+        const idx = segments.findIndex((s) => s.toLowerCase() === detected);
+        if (idx >= 0) segments[idx] = preferredLocale.toLowerCase();
+      }
+    }
+
+    if (preferredVersion) {
+      const detected = extractVersionFromUrl(filterBase);
+      if (detected && detected.toLowerCase() !== preferredVersion.toLowerCase()) {
+        const idx = segments.findIndex((s) => s === detected);
+        if (idx >= 0) segments[idx] = preferredVersion;
+      }
+    }
+
+    url.pathname = '/' + segments.join('/');
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return filterBase;
+  }
+}
+
+/**
  * Check whether a single URL falls under the given path prefix.
  *
  * Returns true when the baseUrl is at the root (no filtering needed),
@@ -695,9 +737,13 @@ export function filterByPathPrefix(urls: string[], baseUrl: string): string[] {
 export async function getPageUrls(ctx: CheckContext): Promise<PageUrlResult> {
   const warnings: string[] = [];
 
-  const filterBase = getPathFilterBase(ctx);
   const locale = ctx.options.preferredLocale ?? extractLocaleFromUrl(ctx.baseUrl);
   const version = ctx.options.preferredVersion ?? extractVersionFromUrl(ctx.baseUrl);
+  const filterBase = rewriteFilterBase(
+    getPathFilterBase(ctx),
+    ctx.options.preferredLocale,
+    ctx.options.preferredVersion,
+  );
 
   /** Apply locale and version filtering to a discovered URL set. */
   function refineUrls(urls: string[]): string[] {

--- a/src/helpers/get-page-urls.ts
+++ b/src/helpers/get-page-urls.ts
@@ -290,6 +290,162 @@ export function filterLocaleSitemaps(subSitemapUrls: string[]): string[] {
   return [...preferred, ...nonLocale].length > 0 ? [...preferred, ...nonLocale] : subSitemapUrls;
 }
 
+/**
+ * Version segment pattern: matches common versioning conventions in URL paths.
+ *
+ * Matches segments like: v2, v3.1, 2.x, 3.0.1, 1.8, latest, stable, current, dev, next
+ * Does NOT match bare integers (e.g. `42`) since those are often page numbers or IDs.
+ * Bare integers require a `v` prefix (e.g. `v2`) to be recognized as versions.
+ */
+const VERSION_SEGMENT =
+  /^(v\d+(\.\d+)*(\.[x*])?|\d+\.\d+(\.\d+)*(\.[x*])?|\d+\.[x*]|latest|stable|current|dev|next|nightly|canary)$/i;
+
+/**
+ * Extract a version-like segment from a URL path, if present.
+ * Returns the version string (e.g. `6.0`, `v2`, `latest`) or null.
+ */
+export function extractVersionFromUrl(url: string): string | null {
+  try {
+    const segments = new URL(url).pathname.split('/').filter(Boolean);
+    for (const seg of segments) {
+      if (VERSION_SEGMENT.test(seg)) return seg;
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+/**
+ * Detect versioned URL duplicates and deduplicate to the "current" version.
+ *
+ * When a sitemap contains the same page under multiple version prefixes
+ * (e.g., `/docs/2.x/foo`, `/docs/3.1.1/foo`, `/docs/foo`), this function
+ * groups them by their non-version path and keeps only one variant per page.
+ *
+ * Priority when `preferredVersion` is set: that version wins.
+ * Default priority: unversioned > `latest`/`stable`/`current` > highest semver.
+ *
+ * Returns the original array if no version duplication is detected (i.e.,
+ * fewer than 20% of URLs share a path suffix with another URL under a
+ * different version prefix).
+ */
+export function deduplicateVersionedUrls(
+  urls: string[],
+  preferredVersion?: string | null,
+): string[] {
+  if (urls.length < 2) return urls;
+
+  // For each URL, try to split it into (prefix, version, suffix).
+  // If no version segment is found, it's unversioned.
+  interface ParsedUrl {
+    url: string;
+    prefix: string; // path segments before the version
+    version: string | null; // the version segment, or null if unversioned
+    suffix: string; // path segments after the version
+    key: string; // prefix + suffix, used for grouping
+  }
+
+  const parsed: ParsedUrl[] = [];
+  for (const url of urls) {
+    try {
+      const u = new URL(url);
+      const segments = u.pathname.split('/').filter(Boolean);
+      let versionIdx = -1;
+      for (let i = 0; i < segments.length; i++) {
+        if (VERSION_SEGMENT.test(segments[i])) {
+          versionIdx = i;
+          break;
+        }
+      }
+
+      if (versionIdx >= 0) {
+        const prefix = segments.slice(0, versionIdx).join('/');
+        const suffix = segments.slice(versionIdx + 1).join('/');
+        parsed.push({
+          url,
+          prefix,
+          version: segments[versionIdx],
+          suffix,
+          key: [prefix, suffix].filter(Boolean).join('/'),
+        });
+      } else {
+        // Unversioned: key is the full path so it can group with versioned
+        // variants that have the same prefix + suffix.
+        parsed.push({
+          url,
+          prefix: segments.join('/'),
+          version: null,
+          suffix: '',
+          key: segments.join('/'),
+        });
+      }
+    } catch {
+      parsed.push({ url, prefix: '', version: null, suffix: '', key: url });
+    }
+  }
+
+  // Group by key to find duplicates
+  const groups = new Map<string, ParsedUrl[]>();
+  for (const p of parsed) {
+    if (!groups.has(p.key)) groups.set(p.key, []);
+    groups.get(p.key)!.push(p);
+  }
+
+  // Count how many URLs are in groups with multiple versions
+  const duplicatedCount = Array.from(groups.values())
+    .filter((g) => g.length > 1)
+    .reduce((sum, g) => sum + g.length, 0);
+
+  // Only deduplicate if a significant portion (>=20%) of URLs have version duplicates
+  if (duplicatedCount < urls.length * 0.2) return urls;
+
+  // For each group, pick the best variant
+  const result: string[] = [];
+  const seen = new Set<string>();
+
+  for (const p of parsed) {
+    if (seen.has(p.key)) continue;
+    seen.add(p.key);
+
+    const group = groups.get(p.key)!;
+    if (group.length === 1) {
+      result.push(group[0].url);
+      continue;
+    }
+
+    // If the user's base URL contains a specific version, prefer that
+    if (preferredVersion) {
+      const match = group.find((g) => g.version?.toLowerCase() === preferredVersion.toLowerCase());
+      if (match) {
+        result.push(match.url);
+        continue;
+      }
+    }
+
+    // Default priority: unversioned > latest/stable/current > highest version
+    const unversioned = group.find((g) => g.version === null);
+    if (unversioned) {
+      result.push(unversioned.url);
+      continue;
+    }
+
+    const latestStable = group.find((g) => /^(latest|stable|current)$/i.test(g.version ?? ''));
+    if (latestStable) {
+      result.push(latestStable.url);
+      continue;
+    }
+
+    // Pick the highest version by string sort (good enough for semver-ish)
+    const sorted = [...group].sort((a, b) =>
+      (b.version ?? '').localeCompare(a.version ?? '', undefined, { numeric: true }),
+    );
+    result.push(sorted[0].url);
+  }
+
+  return result;
+}
+
 async function fetchSitemap(
   ctx: CheckContext,
   sitemapUrl: string,
@@ -367,7 +523,7 @@ export async function getUrlsFromSitemap(
     }
   }
 
-  return urls;
+  return deduplicateVersionedUrls(urls, extractVersionFromUrl(ctx.baseUrl));
 }
 
 /**

--- a/src/helpers/get-page-urls.ts
+++ b/src/helpers/get-page-urls.ts
@@ -247,6 +247,49 @@ function isGzipped(url: string): boolean {
   return /\.gz($|\?)/i.test(url);
 }
 
+/**
+ * Detect whether sub-sitemap URLs follow a locale naming convention and, if so,
+ * filter to the default locale (preferring 'en').
+ *
+ * Common patterns:
+ * - `sitemap-en.xml`, `sitemap-fr.xml`, `sitemap-el.xml`
+ * - `/en/sitemap.xml`, `/fr/sitemap.xml`
+ *
+ * Returns the original array unchanged if no locale pattern is detected.
+ */
+export function filterLocaleSitemaps(subSitemapUrls: string[]): string[] {
+  if (subSitemapUrls.length < 2) return subSitemapUrls;
+
+  // Pattern 1: locale code in filename (sitemap-{locale}.xml)
+  const filenameLocalePattern = /\/sitemap-([a-z]{2}(?:-[a-z]{2})?)\.xml$/i;
+  // Pattern 2: locale code in path segment (/{locale}/sitemap.xml)
+  const pathLocalePattern = /\/([a-z]{2}(?:-[a-z]{2})?)\/sitemap[^/]*\.xml$/i;
+
+  const locales = new Map<string, string[]>();
+  const nonLocale: string[] = [];
+
+  for (const url of subSitemapUrls) {
+    const filenameMatch = filenameLocalePattern.exec(url);
+    const pathMatch = pathLocalePattern.exec(url);
+    const match = filenameMatch ?? pathMatch;
+
+    if (match) {
+      const locale = match[1].toLowerCase();
+      if (!locales.has(locale)) locales.set(locale, []);
+      locales.get(locale)!.push(url);
+    } else {
+      nonLocale.push(url);
+    }
+  }
+
+  // Need at least 2 distinct locale codes to consider this a locale-organized index
+  if (locales.size < 2) return subSitemapUrls;
+
+  // Prefer 'en', then any non-locale sitemaps
+  const preferred = locales.get('en') ?? [];
+  return [...preferred, ...nonLocale].length > 0 ? [...preferred, ...nonLocale] : subSitemapUrls;
+}
+
 async function fetchSitemap(
   ctx: CheckContext,
   sitemapUrl: string,
@@ -306,9 +349,10 @@ export async function getUrlsFromSitemap(
       }
     }
 
-    // Follow one level of sitemap index
+    // Follow one level of sitemap index, filtering to default locale if detected
     if (parsed.sitemapIndexUrls.length > 0 && urls.length < maxUrls) {
-      for (const subSitemapUrl of parsed.sitemapIndexUrls) {
+      const filteredSubSitemaps = filterLocaleSitemaps(parsed.sitemapIndexUrls);
+      for (const subSitemapUrl of filteredSubSitemaps) {
         if (urls.length >= maxUrls) break;
 
         const subParsed = await fetchSitemap(ctx, subSitemapUrl, warnings);

--- a/src/helpers/get-page-urls.ts
+++ b/src/helpers/get-page-urls.ts
@@ -318,6 +318,70 @@ export function filterLocaleSitemaps(
 }
 
 /**
+ * Filter page URLs to a single locale when the URL set contains locale-organized paths.
+ *
+ * Detection: for each path segment position, count how many distinct 2-letter
+ * (or xx-yy) codes appear. If a position has ≥2 distinct codes covering >50%
+ * of URLs, it's a locale segment.
+ *
+ * When detected, keeps only URLs matching the preferred locale (from the base
+ * URL), or 'en' as default. Returns the original array if no locale pattern
+ * is detected.
+ */
+export function filterLocalizedUrls(urls: string[], preferredLocale?: string | null): string[] {
+  if (urls.length < 2) return urls;
+
+  // For each path segment position, collect locale-like codes
+  const positionCounts = new Map<number, Map<string, number>>();
+  const positionTotals = new Map<number, number>();
+
+  for (const url of urls) {
+    try {
+      const segments = new URL(url).pathname.split('/').filter(Boolean);
+      for (let i = 0; i < segments.length; i++) {
+        const seg = segments[i].toLowerCase();
+        if (/^[a-z]{2}(-[a-z]{2})?$/.test(seg)) {
+          if (!positionCounts.has(i)) positionCounts.set(i, new Map());
+          const counts = positionCounts.get(i)!;
+          counts.set(seg, (counts.get(seg) ?? 0) + 1);
+          positionTotals.set(i, (positionTotals.get(i) ?? 0) + 1);
+        }
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  // Find the position that looks like a locale segment
+  let localePosition: number | null = null;
+  for (const [pos, counts] of positionCounts) {
+    if (counts.size < 2) continue;
+    const total = positionTotals.get(pos) ?? 0;
+    if (total > urls.length * 0.5) {
+      localePosition = pos;
+      break;
+    }
+  }
+
+  if (localePosition === null) return urls;
+
+  const targetLocale = preferredLocale?.toLowerCase() ?? 'en';
+
+  const filtered = urls.filter((url) => {
+    try {
+      const segments = new URL(url).pathname.split('/').filter(Boolean);
+      if (segments.length <= localePosition!) return true; // keep URLs without enough segments
+      return segments[localePosition!].toLowerCase() === targetLocale;
+    } catch {
+      return true;
+    }
+  });
+
+  // If filtering removed everything (target locale not present), return original
+  return filtered.length > 0 ? filtered : urls;
+}
+
+/**
  * Version segment pattern: matches common versioning conventions in URL paths.
  *
  * Matches segments like: v2, v3.1, 2.x, 3.0.1, 1.8, latest, stable, current, dev, next
@@ -553,7 +617,8 @@ export async function getUrlsFromSitemap(
     }
   }
 
-  return deduplicateVersionedUrls(urls, extractVersionFromUrl(ctx.baseUrl));
+  const localeFiltered = filterLocalizedUrls(urls, extractLocaleFromUrl(ctx.baseUrl));
+  return deduplicateVersionedUrls(localeFiltered, extractVersionFromUrl(ctx.baseUrl));
 }
 
 /**
@@ -616,20 +681,28 @@ export async function getPageUrls(ctx: CheckContext): Promise<PageUrlResult> {
   const warnings: string[] = [];
 
   const filterBase = getPathFilterBase(ctx);
+  const baseLocale = extractLocaleFromUrl(ctx.baseUrl);
+  const baseVersion = extractVersionFromUrl(ctx.baseUrl);
+
+  /** Apply locale and version filtering to a discovered URL set. */
+  function refineUrls(urls: string[]): string[] {
+    const localeFiltered = filterLocalizedUrls(urls, baseLocale);
+    return deduplicateVersionedUrls(localeFiltered, baseVersion);
+  }
 
   // 1. Try llms.txt links from cached results (if llms-txt-exists ran)
   const cachedUrls = await getUrlsFromCachedLlmsTxt(ctx);
-  const scopedCachedUrls = filterByPathPrefix(cachedUrls, filterBase);
+  const scopedCachedUrls = refineUrls(filterByPathPrefix(cachedUrls, filterBase));
   if (scopedCachedUrls.length > 0) return { urls: scopedCachedUrls, warnings };
 
   // 2. Try fetching llms.txt directly (standalone mode, llms-txt-exists didn't run)
   if (!ctx.previousResults.has('llms-txt-exists')) {
     const fetchedUrls = await fetchLlmsTxtUrls(ctx);
-    const scopedFetchedUrls = filterByPathPrefix(fetchedUrls, filterBase);
+    const scopedFetchedUrls = refineUrls(filterByPathPrefix(fetchedUrls, filterBase));
     if (scopedFetchedUrls.length > 0) return { urls: scopedFetchedUrls, warnings };
   }
 
-  // 3. Try sitemap (path filtering applied inside, before the URL cap)
+  // 3. Try sitemap (path, locale, and version filtering applied inside)
   const sitemapUrls = await getUrlsFromSitemap(ctx, warnings, undefined, undefined, filterBase);
   if (sitemapUrls.length > 0) return { urls: sitemapUrls, warnings };
 

--- a/src/helpers/get-page-urls.ts
+++ b/src/helpers/get-page-urls.ts
@@ -563,6 +563,8 @@ export async function getUrlsFromSitemap(
   maxUrls: number = MAX_SITEMAP_URLS,
   originOverride?: string,
   pathFilterBase?: string,
+  /** Skip URL-level locale/version refinement. Use when the caller needs raw URLs (e.g. freshness coverage). */
+  skipRefinement?: boolean,
 ): Promise<string[]> {
   const sitemapUrls = await discoverSitemapUrls(ctx, originOverride);
   const urls: string[] = [];
@@ -616,6 +618,8 @@ export async function getUrlsFromSitemap(
       }
     }
   }
+
+  if (skipRefinement) return urls;
 
   const localeFiltered = filterLocalizedUrls(
     urls,

--- a/src/helpers/get-page-urls.ts
+++ b/src/helpers/get-page-urls.ts
@@ -557,15 +557,20 @@ async function fetchSitemap(
   }
 }
 
+export interface SitemapOptions {
+  maxUrls?: number;
+  originOverride?: string;
+  pathFilterBase?: string;
+  /** Skip URL-level locale/version refinement. Use when the caller needs raw URLs (e.g. freshness coverage). */
+  skipRefinement?: boolean;
+}
+
 export async function getUrlsFromSitemap(
   ctx: CheckContext,
   warnings: string[],
-  maxUrls: number = MAX_SITEMAP_URLS,
-  originOverride?: string,
-  pathFilterBase?: string,
-  /** Skip URL-level locale/version refinement. Use when the caller needs raw URLs (e.g. freshness coverage). */
-  skipRefinement?: boolean,
+  opts: SitemapOptions = {},
 ): Promise<string[]> {
+  const { maxUrls = MAX_SITEMAP_URLS, originOverride, pathFilterBase, skipRefinement } = opts;
   const sitemapUrls = await discoverSitemapUrls(ctx, originOverride);
   const urls: string[] = [];
   const matchOrigin = originOverride ?? ctx.origin;
@@ -713,7 +718,7 @@ export async function getPageUrls(ctx: CheckContext): Promise<PageUrlResult> {
   }
 
   // 3. Try sitemap (path, locale, and version filtering applied inside)
-  const sitemapUrls = await getUrlsFromSitemap(ctx, warnings, undefined, undefined, filterBase);
+  const sitemapUrls = await getUrlsFromSitemap(ctx, warnings, { pathFilterBase: filterBase });
   if (sitemapUrls.length > 0) return { urls: sitemapUrls, warnings };
 
   // 4. Fallback

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,6 +78,10 @@ export interface CheckOptions {
   samplingStrategy: SamplingStrategy;
   /** Size thresholds. */
   thresholds: SizeThresholds;
+  /** Preferred locale for URL discovery (e.g. 'en', 'fr', 'ja'). Overrides auto-detection from baseUrl. */
+  preferredLocale?: string;
+  /** Preferred version for URL discovery (e.g. 'v3', '2.x', 'latest'). Overrides auto-detection from baseUrl. */
+  preferredVersion?: string;
 }
 
 export interface SizeThresholds {

--- a/test/unit/checks/llms-txt-freshness.test.ts
+++ b/test/unit/checks/llms-txt-freshness.test.ts
@@ -289,6 +289,10 @@ describe('llms-txt-freshness', () => {
       http.get(`http://${host}/robots.txt`, () => new HttpResponse('', { status: 404 })),
       http.get(`http://${host}/sitemap.xml`, () => new HttpResponse('', { status: 404 })),
       http.get(`http://${host}/docs/sitemap.xml`, () => new HttpResponse('', { status: 404 })),
+      http.get(
+        `http://${host}/docs/sitemap-index.xml`,
+        () => new HttpResponse('', { status: 404 }),
+      ),
     );
 
     const result = await check.run(ctx);
@@ -542,12 +546,18 @@ describe('llms-txt-freshness', () => {
             headers: { 'content-type': 'application/xml' },
           }),
       ),
+      http.get(
+        `http://${host}/docs/sitemap-index.xml`,
+        () => new HttpResponse('', { status: 404 }),
+      ),
     );
 
     const result = await check.run(ctx);
     expect(result.status).toBe('pass');
     expect(result.details?.sitemapDocPages).toBe(3);
-    expect(result.details?.sitemapSource).toBe('/docs/sitemap.xml');
+    // getUrlsFromSitemap now discovers the docs sitemap via subpath fallback,
+    // so the freshness check's own fetchDocsSitemap fallback doesn't fire.
+    expect(result.details?.sitemapSource).toBe('robots.txt/sitemap.xml');
   });
 
   test('filters sitemap to matching locale when locale pattern detected', async () => {

--- a/test/unit/checks/llms-txt-freshness.test.ts
+++ b/test/unit/checks/llms-txt-freshness.test.ts
@@ -598,9 +598,8 @@ describe('llms-txt-freshness', () => {
 
     const result = await check.run(ctx);
     expect(result.status).toBe('pass');
-    expect(result.details?.localeFiltered).toBe(true);
-    expect(result.details?.detectedLocale).toBe('en');
-    // After locale filtering, only the 3 English pages remain
+    // Locale filtering now happens inside getUrlsFromSitemap, so the freshness
+    // check receives only English URLs and its own locale detection is a no-op.
     expect(result.details?.sitemapDocPages).toBe(3);
   });
 

--- a/test/unit/cli/check-command.test.ts
+++ b/test/unit/cli/check-command.test.ts
@@ -242,6 +242,45 @@ describe('check command', () => {
     await rm(tmpDir, { recursive: true, force: true });
   });
 
+  it('accepts --locale and --version flags without error', async () => {
+    server.use(
+      http.get('http://cmd-opts.local/llms.txt', () => HttpResponse.text(VALID_LLMS_TXT)),
+      http.get(
+        'http://cmd-opts.local/docs/llms.txt',
+        () => new HttpResponse(null, { status: 404 }),
+      ),
+    );
+
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const { run } = await import('../../../src/cli/index.js');
+    await run([
+      'node',
+      'afdocs',
+      'check',
+      'http://cmd-opts.local',
+      '--checks',
+      'llms-txt-exists',
+      '--request-delay',
+      '0',
+      '--doc-locale',
+      'fr',
+      '--doc-version',
+      'v3',
+      '--format',
+      'json',
+    ]);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    const output = writeSpy.mock.calls.map((c) => c[0]).join('');
+    const parsed = JSON.parse(output.trim());
+    expect(parsed.results[0].id).toBe('llms-txt-exists');
+    expect(parsed.results[0].status).toBe('pass');
+
+    writeSpy.mockRestore();
+  });
+
   it('does not set exit code 1 when all pass', async () => {
     server.use(
       http.get('http://cmd-pass.local/llms.txt', () => HttpResponse.text(VALID_LLMS_TXT)),

--- a/test/unit/helpers/get-page-urls.test.ts
+++ b/test/unit/helpers/get-page-urls.test.ts
@@ -7,6 +7,7 @@ import {
   parseSitemapUrls,
   parseSitemapDirectives,
   filterByPathPrefix,
+  filterLocaleSitemaps,
 } from '../../../src/helpers/get-page-urls.js';
 import { MAX_SITEMAP_URLS } from '../../../src/constants.js';
 import { createContext } from '../../../src/runner.js';
@@ -145,6 +146,73 @@ describe('filterByPathPrefix', () => {
     const urls = ['not-a-url', 'https://example.com/docs/page'];
     const result = filterByPathPrefix(urls, 'https://example.com/docs');
     expect(result).toEqual(['not-a-url', 'https://example.com/docs/page']);
+  });
+});
+
+describe('filterLocaleSitemaps', () => {
+  it('filters to English sub-sitemaps when locale pattern detected in filenames', () => {
+    const urls = [
+      'https://example.com/sitemap-el.xml',
+      'https://example.com/sitemap-en.xml',
+      'https://example.com/sitemap-es.xml',
+      'https://example.com/sitemap-fr.xml',
+    ];
+    const result = filterLocaleSitemaps(urls);
+    expect(result).toEqual(['https://example.com/sitemap-en.xml']);
+  });
+
+  it('filters to English sub-sitemaps when locale pattern detected in paths', () => {
+    const urls = [
+      'https://example.com/el/sitemap.xml',
+      'https://example.com/en/sitemap.xml',
+      'https://example.com/fr/sitemap.xml',
+    ];
+    const result = filterLocaleSitemaps(urls);
+    expect(result).toEqual(['https://example.com/en/sitemap.xml']);
+  });
+
+  it('preserves non-locale sitemaps alongside the default locale', () => {
+    const urls = [
+      'https://example.com/sitemap-pages.xml',
+      'https://example.com/sitemap-en.xml',
+      'https://example.com/sitemap-fr.xml',
+      'https://example.com/sitemap-el.xml',
+    ];
+    const result = filterLocaleSitemaps(urls);
+    expect(result).toEqual([
+      'https://example.com/sitemap-en.xml',
+      'https://example.com/sitemap-pages.xml',
+    ]);
+  });
+
+  it('returns all URLs when no locale pattern is detected', () => {
+    const urls = ['https://example.com/sitemap-docs.xml', 'https://example.com/sitemap-blog.xml'];
+    const result = filterLocaleSitemaps(urls);
+    expect(result).toEqual(urls);
+  });
+
+  it('returns all URLs when only one locale is present', () => {
+    const urls = ['https://example.com/sitemap-en.xml', 'https://example.com/sitemap-pages.xml'];
+    const result = filterLocaleSitemaps(urls);
+    expect(result).toEqual(urls);
+  });
+
+  it('returns single URL unchanged', () => {
+    const urls = ['https://example.com/sitemap.xml'];
+    expect(filterLocaleSitemaps(urls)).toEqual(urls);
+  });
+
+  it('handles locale codes with region subtags', () => {
+    const urls = [
+      'https://example.com/sitemap-en-us.xml',
+      'https://example.com/sitemap-fr-fr.xml',
+      'https://example.com/sitemap-de-de.xml',
+    ];
+    // No plain 'en', so all region-tagged locales returned (no preferred match)
+    // Actually, these are distinct locales with region tags; en is not present
+    const result = filterLocaleSitemaps(urls);
+    // No 'en' match, no non-locale sitemaps → falls back to all
+    expect(result).toEqual(urls);
   });
 });
 
@@ -393,6 +461,47 @@ describe('getPageUrls', () => {
     // don't consume cap slots. All 50 English URLs should be found.
     expect(result.urls.length).toBe(50);
     expect(result.urls.every((u) => u.includes('/en/6.0/'))).toBe(true);
+  });
+
+  it('filters sitemap index to default locale, skipping non-English sub-sitemaps (#30)', async () => {
+    // Django-like sitemap index: 12 locale sitemaps, only en should be fetched
+    server.use(
+      http.get('http://locale-idx.local/robots.txt', () => new HttpResponse('', { status: 404 })),
+      http.get(
+        'http://locale-idx.local/sitemap.xml',
+        () =>
+          new HttpResponse(
+            `<?xml version="1.0"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>http://locale-idx.local/sitemap-el.xml</loc></sitemap>
+  <sitemap><loc>http://locale-idx.local/sitemap-en.xml</loc></sitemap>
+  <sitemap><loc>http://locale-idx.local/sitemap-es.xml</loc></sitemap>
+  <sitemap><loc>http://locale-idx.local/sitemap-fr.xml</loc></sitemap>
+</sitemapindex>`,
+            { status: 200, headers: { 'Content-Type': 'application/xml' } },
+          ),
+      ),
+      http.get(
+        'http://locale-idx.local/sitemap-en.xml',
+        () =>
+          new HttpResponse(
+            `<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>http://locale-idx.local/en/docs/intro</loc></url>
+  <url><loc>http://locale-idx.local/en/docs/guide</loc></url>
+</urlset>`,
+            { status: 200, headers: { 'Content-Type': 'application/xml' } },
+          ),
+      ),
+      // el, es, fr sitemaps should NOT be fetched — no mocks needed
+      // (if they were fetched, the test would timeout)
+    );
+
+    const ctx = makeCtx('http://locale-idx.local');
+    const result = await getPageUrls(ctx);
+    expect(result.urls).toEqual([
+      'http://locale-idx.local/en/docs/intro',
+      'http://locale-idx.local/en/docs/guide',
+    ]);
   });
 
   it('handles sitemap fetch network errors gracefully', async () => {

--- a/test/unit/helpers/get-page-urls.test.ts
+++ b/test/unit/helpers/get-page-urls.test.ts
@@ -8,6 +8,8 @@ import {
   parseSitemapDirectives,
   filterByPathPrefix,
   filterLocaleSitemaps,
+  deduplicateVersionedUrls,
+  extractVersionFromUrl,
 } from '../../../src/helpers/get-page-urls.js';
 import { MAX_SITEMAP_URLS } from '../../../src/constants.js';
 import { createContext } from '../../../src/runner.js';
@@ -213,6 +215,171 @@ describe('filterLocaleSitemaps', () => {
     const result = filterLocaleSitemaps(urls);
     // No 'en' match, no non-locale sitemaps → falls back to all
     expect(result).toEqual(urls);
+  });
+});
+
+describe('deduplicateVersionedUrls', () => {
+  it('deduplicates Docusaurus-style versioned URLs, keeping unversioned', () => {
+    const urls = [
+      'https://example.com/docs/2.x/intro',
+      'https://example.com/docs/3.0.1/intro',
+      'https://example.com/docs/3.1.1/intro',
+      'https://example.com/docs/intro',
+      'https://example.com/docs/2.x/guide',
+      'https://example.com/docs/3.0.1/guide',
+      'https://example.com/docs/guide',
+    ];
+    const result = deduplicateVersionedUrls(urls);
+    expect(result).toEqual(['https://example.com/docs/intro', 'https://example.com/docs/guide']);
+  });
+
+  it('prefers latest/stable when no unversioned variant exists', () => {
+    const urls = [
+      'https://example.com/en/v1/intro',
+      'https://example.com/en/v2/intro',
+      'https://example.com/en/latest/intro',
+      'https://example.com/en/v1/guide',
+      'https://example.com/en/v2/guide',
+      'https://example.com/en/latest/guide',
+    ];
+    const result = deduplicateVersionedUrls(urls);
+    expect(result).toEqual([
+      'https://example.com/en/latest/intro',
+      'https://example.com/en/latest/guide',
+    ]);
+  });
+
+  it('picks the highest version when no unversioned or latest exists', () => {
+    const urls = [
+      'https://example.com/docs/1.8/intro',
+      'https://example.com/docs/3.0/intro',
+      'https://example.com/docs/2.0/intro',
+      'https://example.com/docs/1.8/guide',
+      'https://example.com/docs/3.0/guide',
+      'https://example.com/docs/2.0/guide',
+    ];
+    const result = deduplicateVersionedUrls(urls);
+    expect(result).toEqual([
+      'https://example.com/docs/3.0/intro',
+      'https://example.com/docs/3.0/guide',
+    ]);
+  });
+
+  it('returns urls unchanged when less than 20% are version-duplicated', () => {
+    // 10 unique pages + 2 version duplicates = 12 total, 2/12 < 20%
+    const urls = [
+      ...Array.from({ length: 10 }, (_, i) => `https://example.com/docs/page-${i}`),
+      'https://example.com/docs/v1/intro',
+      'https://example.com/docs/v2/intro',
+    ];
+    const result = deduplicateVersionedUrls(urls);
+    expect(result).toEqual(urls);
+  });
+
+  it('handles single URL', () => {
+    const urls = ['https://example.com/docs/v1/intro'];
+    expect(deduplicateVersionedUrls(urls)).toEqual(urls);
+  });
+
+  it('handles empty array', () => {
+    expect(deduplicateVersionedUrls([])).toEqual([]);
+  });
+
+  it('handles Read the Docs style versioning', () => {
+    const urls = [
+      'https://example.com/en/stable/tutorial',
+      'https://example.com/en/latest/tutorial',
+      'https://example.com/en/v2/tutorial',
+      'https://example.com/en/stable/api',
+      'https://example.com/en/latest/api',
+      'https://example.com/en/v2/api',
+    ];
+    const result = deduplicateVersionedUrls(urls);
+    // stable is preferred over latest (both are special, but stable sorts after latest)
+    expect(result).toEqual([
+      'https://example.com/en/stable/tutorial',
+      'https://example.com/en/stable/api',
+    ]);
+  });
+
+  it('prefers current as equivalent to latest/stable', () => {
+    const urls = [
+      'https://example.com/docs/v1/intro',
+      'https://example.com/docs/v2/intro',
+      'https://example.com/docs/current/intro',
+      'https://example.com/docs/v1/guide',
+      'https://example.com/docs/v2/guide',
+      'https://example.com/docs/current/guide',
+    ];
+    const result = deduplicateVersionedUrls(urls);
+    expect(result).toEqual([
+      'https://example.com/docs/current/intro',
+      'https://example.com/docs/current/guide',
+    ]);
+  });
+
+  it('prefers the version from the base URL when preferredVersion is set', () => {
+    const urls = [
+      'https://example.com/docs/v1/intro',
+      'https://example.com/docs/v2/intro',
+      'https://example.com/docs/v3/intro',
+      'https://example.com/docs/v1/guide',
+      'https://example.com/docs/v2/guide',
+      'https://example.com/docs/v3/guide',
+    ];
+    // User passed a URL with v2 in it
+    const result = deduplicateVersionedUrls(urls, 'v2');
+    expect(result).toEqual([
+      'https://example.com/docs/v2/intro',
+      'https://example.com/docs/v2/guide',
+    ]);
+  });
+
+  it('falls back to default priority when preferredVersion has no match', () => {
+    const urls = [
+      'https://example.com/docs/v1/intro',
+      'https://example.com/docs/v2/intro',
+      'https://example.com/docs/v1/guide',
+      'https://example.com/docs/v2/guide',
+    ];
+    // User passed a URL with v5 but no v5 exists in the sitemap
+    const result = deduplicateVersionedUrls(urls, 'v5');
+    expect(result).toEqual([
+      'https://example.com/docs/v2/intro',
+      'https://example.com/docs/v2/guide',
+    ]);
+  });
+});
+
+describe('extractVersionFromUrl', () => {
+  it('detects semver-style versions', () => {
+    expect(extractVersionFromUrl('https://example.com/docs/3.0.1/intro')).toBe('3.0.1');
+  });
+
+  it('detects v-prefixed versions', () => {
+    expect(extractVersionFromUrl('https://example.com/en/v2/guide')).toBe('v2');
+  });
+
+  it('detects wildcard versions', () => {
+    expect(extractVersionFromUrl('https://example.com/docs/2.x/intro')).toBe('2.x');
+  });
+
+  it('detects keyword versions', () => {
+    expect(extractVersionFromUrl('https://example.com/en/latest/intro')).toBe('latest');
+    expect(extractVersionFromUrl('https://example.com/en/stable/intro')).toBe('stable');
+    expect(extractVersionFromUrl('https://example.com/en/current/intro')).toBe('current');
+  });
+
+  it('returns null when no version segment is found', () => {
+    expect(extractVersionFromUrl('https://example.com/docs/intro')).toBeNull();
+  });
+
+  it('returns null for bare integers', () => {
+    expect(extractVersionFromUrl('https://example.com/page/42')).toBeNull();
+  });
+
+  it('returns the first version segment found', () => {
+    expect(extractVersionFromUrl('https://example.com/v2/docs/3.0/intro')).toBe('v2');
   });
 });
 
@@ -461,6 +628,42 @@ describe('getPageUrls', () => {
     // don't consume cap slots. All 50 English URLs should be found.
     expect(result.urls.length).toBe(50);
     expect(result.urls.every((u) => u.includes('/en/6.0/'))).toBe(true);
+  });
+
+  it('deduplicates versioned URLs from sitemap to current version (#22)', async () => {
+    // Docusaurus-style: same pages under multiple version prefixes
+    const versionedLocs = [
+      'http://ver-dedup.local/docs/2.x/intro',
+      'http://ver-dedup.local/docs/2.x/guide',
+      'http://ver-dedup.local/docs/3.0.1/intro',
+      'http://ver-dedup.local/docs/3.0.1/guide',
+      'http://ver-dedup.local/docs/3.1.1/intro',
+      'http://ver-dedup.local/docs/3.1.1/guide',
+      'http://ver-dedup.local/docs/intro',
+      'http://ver-dedup.local/docs/guide',
+    ]
+      .map((u) => `  <url><loc>${u}</loc></url>`)
+      .join('\n');
+
+    server.use(
+      http.get('http://ver-dedup.local/robots.txt', () => new HttpResponse('', { status: 404 })),
+      http.get(
+        'http://ver-dedup.local/sitemap.xml',
+        () =>
+          new HttpResponse(
+            `<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${versionedLocs}\n</urlset>`,
+            { status: 200, headers: { 'Content-Type': 'application/xml' } },
+          ),
+      ),
+    );
+
+    const ctx = makeCtx('http://ver-dedup.local');
+    const result = await getPageUrls(ctx);
+    // Should keep only the unversioned (current) variants
+    expect(result.urls).toEqual([
+      'http://ver-dedup.local/docs/intro',
+      'http://ver-dedup.local/docs/guide',
+    ]);
   });
 
   it('filters sitemap index to default locale, skipping non-English sub-sitemaps (#30)', async () => {

--- a/test/unit/helpers/get-page-urls.test.ts
+++ b/test/unit/helpers/get-page-urls.test.ts
@@ -375,6 +375,14 @@ describe('getPageUrls', () => {
             { status: 200, headers: { 'Content-Type': 'application/xml' } },
           ),
       ),
+      http.get(
+        'http://cap-prefix.local/en/6.0/sitemap.xml',
+        () => new HttpResponse('', { status: 404 }),
+      ),
+      http.get(
+        'http://cap-prefix.local/en/6.0/sitemap-index.xml',
+        () => new HttpResponse('', { status: 404 }),
+      ),
     );
 
     // User wants to test /en/6.0/ docs specifically
@@ -779,6 +787,14 @@ describe('getPageUrls', () => {
             { status: 200, headers: { 'Content-Type': 'application/xml' } },
           ),
       ),
+      http.get(
+        'http://sitemap-scope.local/docs/sitemap.xml',
+        () => new HttpResponse('', { status: 404 }),
+      ),
+      http.get(
+        'http://sitemap-scope.local/docs/sitemap-index.xml',
+        () => new HttpResponse('', { status: 404 }),
+      ),
     );
 
     const ctx = makeCtx('http://sitemap-scope.local/docs');
@@ -786,6 +802,50 @@ describe('getPageUrls', () => {
     expect(result.urls).toEqual([
       'http://sitemap-scope.local/docs/intro',
       'http://sitemap-scope.local/docs/guide',
+    ]);
+  });
+
+  it('discovers sitemap at docs subpath when origin-level sitemap is empty (#32)', async () => {
+    // Simulate Swagger UI: robots.txt 404, /sitemap.xml 404, but /docs/sitemap-index.xml exists
+    server.use(
+      http.get('http://subpath-sm.local/robots.txt', () => new HttpResponse('', { status: 404 })),
+      http.get(
+        'http://subpath-sm.local/sitemap.xml',
+        () => new HttpResponse('Not Found', { status: 404 }),
+      ),
+      http.get(
+        'http://subpath-sm.local/docs/sitemap.xml',
+        () => new HttpResponse('Not Found', { status: 404 }),
+      ),
+      http.get(
+        'http://subpath-sm.local/docs/sitemap-index.xml',
+        () =>
+          new HttpResponse(
+            `<?xml version="1.0"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>http://subpath-sm.local/docs/sitemap-0.xml</loc></sitemap>
+</sitemapindex>`,
+            { status: 200, headers: { 'Content-Type': 'application/xml' } },
+          ),
+      ),
+      http.get(
+        'http://subpath-sm.local/docs/sitemap-0.xml',
+        () =>
+          new HttpResponse(
+            `<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>http://subpath-sm.local/docs/getting-started</loc></url>
+  <url><loc>http://subpath-sm.local/docs/configuration</loc></url>
+</urlset>`,
+            { status: 200, headers: { 'Content-Type': 'application/xml' } },
+          ),
+      ),
+    );
+
+    const ctx = makeCtx('http://subpath-sm.local/docs');
+    const result = await getPageUrls(ctx);
+    expect(result.urls).toEqual([
+      'http://subpath-sm.local/docs/getting-started',
+      'http://subpath-sm.local/docs/configuration',
     ]);
   });
 
@@ -811,6 +871,14 @@ describe('getPageUrls', () => {
     server.use(
       http.get('http://filter-all.local/robots.txt', () => new HttpResponse('', { status: 404 })),
       http.get('http://filter-all.local/sitemap.xml', () => new HttpResponse('', { status: 404 })),
+      http.get(
+        'http://filter-all.local/docs/sitemap.xml',
+        () => new HttpResponse('', { status: 404 }),
+      ),
+      http.get(
+        'http://filter-all.local/docs/sitemap-index.xml',
+        () => new HttpResponse('', { status: 404 }),
+      ),
     );
 
     const ctx = makeCtx('http://filter-all.local/docs', content);

--- a/test/unit/helpers/get-page-urls.test.ts
+++ b/test/unit/helpers/get-page-urls.test.ts
@@ -10,6 +10,7 @@ import {
   filterLocaleSitemaps,
   deduplicateVersionedUrls,
   extractVersionFromUrl,
+  extractLocaleFromUrl,
 } from '../../../src/helpers/get-page-urls.js';
 import { MAX_SITEMAP_URLS } from '../../../src/constants.js';
 import { createContext } from '../../../src/runner.js';
@@ -215,6 +216,66 @@ describe('filterLocaleSitemaps', () => {
     const result = filterLocaleSitemaps(urls);
     // No 'en' match, no non-locale sitemaps → falls back to all
     expect(result).toEqual(urls);
+  });
+
+  it('prefers the locale from the base URL when preferredLocale is set', () => {
+    const urls = [
+      'https://example.com/sitemap-el.xml',
+      'https://example.com/sitemap-en.xml',
+      'https://example.com/sitemap-fr.xml',
+    ];
+    const result = filterLocaleSitemaps(urls, 'fr');
+    expect(result).toEqual(['https://example.com/sitemap-fr.xml']);
+  });
+
+  it('falls back to en when preferredLocale has no match', () => {
+    const urls = [
+      'https://example.com/sitemap-el.xml',
+      'https://example.com/sitemap-en.xml',
+      'https://example.com/sitemap-fr.xml',
+    ];
+    const result = filterLocaleSitemaps(urls, 'ja');
+    expect(result).toEqual(['https://example.com/sitemap-en.xml']);
+  });
+
+  it('preserves non-locale sitemaps alongside the preferred locale', () => {
+    const urls = [
+      'https://example.com/sitemap-pages.xml',
+      'https://example.com/sitemap-en.xml',
+      'https://example.com/sitemap-fr.xml',
+      'https://example.com/sitemap-de.xml',
+    ];
+    const result = filterLocaleSitemaps(urls, 'de');
+    expect(result).toEqual([
+      'https://example.com/sitemap-de.xml',
+      'https://example.com/sitemap-pages.xml',
+    ]);
+  });
+});
+
+describe('extractLocaleFromUrl', () => {
+  it('detects 2-letter locale in URL path', () => {
+    expect(extractLocaleFromUrl('https://example.com/fr/docs/intro')).toBe('fr');
+  });
+
+  it('detects locale with region subtag', () => {
+    expect(extractLocaleFromUrl('https://example.com/pt-br/docs/intro')).toBe('pt-br');
+  });
+
+  it('detects locale after a non-locale segment', () => {
+    expect(extractLocaleFromUrl('https://example.com/docs/en/intro')).toBe('en');
+  });
+
+  it('returns null when no locale segment is found', () => {
+    expect(extractLocaleFromUrl('https://example.com/docs/intro')).toBeNull();
+  });
+
+  it('does not match segments beyond the first 3 path positions', () => {
+    expect(extractLocaleFromUrl('https://example.com/a/b/c/fr/page')).toBeNull();
+  });
+
+  it('returns the first locale segment found', () => {
+    expect(extractLocaleFromUrl('https://example.com/en/fr/intro')).toBe('en');
   });
 });
 

--- a/test/unit/helpers/get-page-urls.test.ts
+++ b/test/unit/helpers/get-page-urls.test.ts
@@ -472,6 +472,36 @@ describe('deduplicateVersionedUrls', () => {
     ]);
   });
 
+  it('ranks pre-release channels (dev, next, nightly, canary) below stable versions', () => {
+    const urls = [
+      'https://example.com/en/dev/intro',
+      'https://example.com/en/6.0/intro',
+      'https://example.com/en/5.2/intro',
+      'https://example.com/en/dev/guide',
+      'https://example.com/en/6.0/guide',
+      'https://example.com/en/5.2/guide',
+    ];
+    const result = deduplicateVersionedUrls(urls);
+    expect(result).toEqual([
+      'https://example.com/en/6.0/intro',
+      'https://example.com/en/6.0/guide',
+    ]);
+  });
+
+  it('uses pre-release when no stable versions exist', () => {
+    const urls = [
+      'https://example.com/en/dev/intro',
+      'https://example.com/en/nightly/intro',
+      'https://example.com/en/dev/guide',
+      'https://example.com/en/nightly/guide',
+    ];
+    const result = deduplicateVersionedUrls(urls);
+    expect(result).toEqual([
+      'https://example.com/en/dev/intro',
+      'https://example.com/en/dev/guide',
+    ]);
+  });
+
   it('passes through singleton groups alongside deduplicated groups', () => {
     const urls = [
       'https://example.com/docs/v1/intro',

--- a/test/unit/helpers/get-page-urls.test.ts
+++ b/test/unit/helpers/get-page-urls.test.ts
@@ -8,6 +8,7 @@ import {
   parseSitemapDirectives,
   filterByPathPrefix,
   filterLocaleSitemaps,
+  filterLocalizedUrls,
   deduplicateVersionedUrls,
   extractVersionFromUrl,
   extractLocaleFromUrl,
@@ -276,6 +277,63 @@ describe('extractLocaleFromUrl', () => {
 
   it('returns the first locale segment found', () => {
     expect(extractLocaleFromUrl('https://example.com/en/fr/intro')).toBe('en');
+  });
+});
+
+describe('filterLocalizedUrls', () => {
+  it('filters page URLs to English when multiple locales detected', () => {
+    const urls = [
+      'https://example.com/en/docs/intro',
+      'https://example.com/en/docs/guide',
+      'https://example.com/fr/docs/intro',
+      'https://example.com/fr/docs/guide',
+      'https://example.com/de/docs/intro',
+      'https://example.com/de/docs/guide',
+    ];
+    const result = filterLocalizedUrls(urls);
+    expect(result).toEqual([
+      'https://example.com/en/docs/intro',
+      'https://example.com/en/docs/guide',
+    ]);
+  });
+
+  it('prefers the locale from the base URL', () => {
+    const urls = [
+      'https://example.com/en/docs/intro',
+      'https://example.com/fr/docs/intro',
+      'https://example.com/de/docs/intro',
+      'https://example.com/en/docs/guide',
+      'https://example.com/fr/docs/guide',
+      'https://example.com/de/docs/guide',
+    ];
+    const result = filterLocalizedUrls(urls, 'fr');
+    expect(result).toEqual([
+      'https://example.com/fr/docs/intro',
+      'https://example.com/fr/docs/guide',
+    ]);
+  });
+
+  it('returns all URLs when no locale pattern is detected', () => {
+    const urls = [
+      'https://example.com/docs/intro',
+      'https://example.com/docs/guide',
+      'https://example.com/docs/api',
+    ];
+    const result = filterLocalizedUrls(urls);
+    expect(result).toEqual(urls);
+  });
+
+  it('returns all URLs when only one locale is present', () => {
+    const urls = ['https://example.com/en/docs/intro', 'https://example.com/en/docs/guide'];
+    const result = filterLocalizedUrls(urls);
+    expect(result).toEqual(urls);
+  });
+
+  it('falls back to all URLs when preferred locale is not present', () => {
+    const urls = ['https://example.com/en/docs/intro', 'https://example.com/fr/docs/intro'];
+    const result = filterLocalizedUrls(urls, 'ja');
+    // ja not present → returns all
+    expect(result).toEqual(urls);
   });
 });
 
@@ -1126,6 +1184,39 @@ describe('getPageUrls', () => {
     expect(result.urls).toEqual([
       'http://scope-test.local/docs/intro',
       'http://scope-test.local/docs/guide',
+    ]);
+  });
+
+  it('filters llms.txt URLs by locale when multiple locales present', async () => {
+    const content = `# Docs\n## Links\n- [EN Intro](http://locale-llms.local/en/docs/intro): Intro\n- [EN Guide](http://locale-llms.local/en/docs/guide): Guide\n- [FR Intro](http://locale-llms.local/fr/docs/intro): Intro\n- [FR Guide](http://locale-llms.local/fr/docs/guide): Guide\n- [DE Intro](http://locale-llms.local/de/docs/intro): Intro\n- [DE Guide](http://locale-llms.local/de/docs/guide): Guide\n`;
+    // No locale in base URL → defaults to 'en'
+    const ctx = makeCtx('http://locale-llms.local', content);
+
+    const result = await getPageUrls(ctx);
+    expect(result.urls).toEqual([
+      'http://locale-llms.local/en/docs/intro',
+      'http://locale-llms.local/en/docs/guide',
+    ]);
+  });
+
+  it('filters llms.txt URLs to preferred locale from base URL', async () => {
+    const content = `# Docs\n## Links\n- [EN](http://locale-pref.local/en/docs/intro): Intro\n- [FR](http://locale-pref.local/fr/docs/intro): Intro\n- [DE](http://locale-pref.local/de/docs/intro): Intro\n`;
+    // User passed /fr/ in base URL
+    const ctx = makeCtx('http://locale-pref.local/fr', content);
+
+    const result = await getPageUrls(ctx);
+    expect(result.urls).toEqual(['http://locale-pref.local/fr/docs/intro']);
+  });
+
+  it('deduplicates versioned URLs from llms.txt', async () => {
+    const content = `# Docs\n## Links\n- [v1](http://ver-llms.local/docs/v1/intro): Intro v1\n- [v2](http://ver-llms.local/docs/v2/intro): Intro v2\n- [v3](http://ver-llms.local/docs/v3/intro): Intro v3\n- [v1 Guide](http://ver-llms.local/docs/v1/guide): Guide v1\n- [v2 Guide](http://ver-llms.local/docs/v2/guide): Guide v2\n- [v3 Guide](http://ver-llms.local/docs/v3/guide): Guide v3\n`;
+    const ctx = makeCtx('http://ver-llms.local', content);
+
+    const result = await getPageUrls(ctx);
+    // No version in base URL → defaults to highest (v3)
+    expect(result.urls).toEqual([
+      'http://ver-llms.local/docs/v3/intro',
+      'http://ver-llms.local/docs/v3/guide',
     ]);
   });
 

--- a/test/unit/helpers/get-page-urls.test.ts
+++ b/test/unit/helpers/get-page-urls.test.ts
@@ -3,6 +3,7 @@ import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import {
   getPageUrls,
+  getUrlsFromSitemap,
   discoverAndSamplePages,
   parseSitemapUrls,
   parseSitemapDirectives,
@@ -335,6 +336,23 @@ describe('filterLocalizedUrls', () => {
     // ja not present → returns all
     expect(result).toEqual(urls);
   });
+
+  it('keeps URLs with fewer segments than the locale position', () => {
+    // Locale at position 1 (docs/{locale}/...), so a URL with only 1 segment
+    // doesn't reach the locale position and should be kept, not dropped.
+    const urls = [
+      'https://example.com/docs/en/intro',
+      'https://example.com/docs/fr/intro',
+      'https://example.com/docs/en/guide',
+      'https://example.com/docs/fr/guide',
+      'https://example.com/docs', // only 1 segment, can't have locale at position 1
+    ];
+    const result = filterLocalizedUrls(urls);
+    expect(result).toContain('https://example.com/docs/en/intro');
+    expect(result).toContain('https://example.com/docs/en/guide');
+    expect(result).toContain('https://example.com/docs'); // kept, not dropped
+    expect(result).not.toContain('https://example.com/docs/fr/intro');
+  });
 });
 
 describe('deduplicateVersionedUrls', () => {
@@ -452,6 +470,23 @@ describe('deduplicateVersionedUrls', () => {
       'https://example.com/docs/v2/intro',
       'https://example.com/docs/v2/guide',
     ]);
+  });
+
+  it('passes through singleton groups alongside deduplicated groups', () => {
+    const urls = [
+      'https://example.com/docs/v1/intro',
+      'https://example.com/docs/v2/intro',
+      'https://example.com/docs/v3/intro',
+      'https://example.com/docs/v1/guide',
+      'https://example.com/docs/v2/guide',
+      'https://example.com/docs/v3/guide',
+      'https://example.com/docs/unique-page', // no version duplicates
+    ];
+    const result = deduplicateVersionedUrls(urls);
+    expect(result).toContain('https://example.com/docs/v3/intro');
+    expect(result).toContain('https://example.com/docs/v3/guide');
+    expect(result).toContain('https://example.com/docs/unique-page');
+    expect(result).toHaveLength(3);
   });
 
   it('falls back to default priority when preferredVersion has no match', () => {
@@ -1065,6 +1100,42 @@ describe('getPageUrls', () => {
     expect(result.urls).toEqual(['http://walk-err.local']);
   });
 
+  it('skips aggregate .txt files with non-text content-type', async () => {
+    const rootContent = `# Docs\n- [Data](http://walk-ct.local/data.txt)\n- [Page](http://walk-ct.local/docs/page): Page\n`;
+    server.use(
+      http.get(
+        'http://walk-ct.local/data.txt',
+        () =>
+          new HttpResponse('{"key": "value"}', {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+      ),
+    );
+
+    const ctx = makeCtx('http://walk-ct.local', rootContent);
+    const result = await getPageUrls(ctx);
+    expect(result.urls).toEqual(['http://walk-ct.local/docs/page']);
+  });
+
+  it('skips aggregate .txt files with empty content', async () => {
+    const rootContent = `# Docs\n- [Empty](http://walk-empty.local/empty.txt)\n- [Page](http://walk-empty.local/docs/page): Page\n`;
+    server.use(
+      http.get(
+        'http://walk-empty.local/empty.txt',
+        () =>
+          new HttpResponse('   ', {
+            status: 200,
+            headers: { 'Content-Type': 'text/plain' },
+          }),
+      ),
+    );
+
+    const ctx = makeCtx('http://walk-empty.local', rootContent);
+    const result = await getPageUrls(ctx);
+    expect(result.urls).toEqual(['http://walk-empty.local/docs/page']);
+  });
+
   // ── Direct llms.txt fetch (standalone mode) ──
 
   it('fetches llms.txt directly when llms-txt-exists has not run', async () => {
@@ -1378,6 +1449,186 @@ describe('getPageUrls', () => {
     expect(result.urls).toEqual(['http://gz-mixed.local/page']);
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toContain('sitemap.xml.gz');
+  });
+
+  it('explicit preferredLocale overrides locale detected from base URL', async () => {
+    const content = `# Docs\n## Links\n- [EN](http://opt-locale.local/en/docs/intro): Intro\n- [FR](http://opt-locale.local/fr/docs/intro): Intro\n- [DE](http://opt-locale.local/de/docs/intro): Intro\n`;
+    // Base URL has /en/ but explicit option says 'de' — path prefix
+    // should be rewritten from /en to /de so the right URLs pass through
+    const ctx = makeCtx('http://opt-locale.local/en', content);
+    ctx.options.preferredLocale = 'de';
+
+    const result = await getPageUrls(ctx);
+    expect(result.urls).toEqual(['http://opt-locale.local/de/docs/intro']);
+  });
+
+  it('explicit preferredVersion overrides version detected from base URL', async () => {
+    const content = `# Docs\n## Links\n- [v1](http://opt-ver.local/docs/v1/intro): v1\n- [v2](http://opt-ver.local/docs/v2/intro): v2\n- [v3](http://opt-ver.local/docs/v3/intro): v3\n- [v1 Guide](http://opt-ver.local/docs/v1/guide): v1\n- [v2 Guide](http://opt-ver.local/docs/v2/guide): v2\n- [v3 Guide](http://opt-ver.local/docs/v3/guide): v3\n`;
+    // Base URL has /v3/ but explicit option says 'v1' — path prefix
+    // should be rewritten from /docs/v3 to /docs/v1
+    const ctx = makeCtx('http://opt-ver.local/docs/v3', content);
+    ctx.options.preferredVersion = 'v1';
+
+    const result = await getPageUrls(ctx);
+    expect(result.urls).toEqual([
+      'http://opt-ver.local/docs/v1/intro',
+      'http://opt-ver.local/docs/v1/guide',
+    ]);
+  });
+
+  it('explicit preferredLocale applies to sitemap index filtering', async () => {
+    server.use(
+      http.get(
+        'http://opt-sitemap-locale.local/robots.txt',
+        () => new HttpResponse('', { status: 404 }),
+      ),
+      http.get(
+        'http://opt-sitemap-locale.local/sitemap.xml',
+        () =>
+          new HttpResponse(
+            `<?xml version="1.0"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>http://opt-sitemap-locale.local/sitemap-en.xml</loc></sitemap>
+  <sitemap><loc>http://opt-sitemap-locale.local/sitemap-ja.xml</loc></sitemap>
+  <sitemap><loc>http://opt-sitemap-locale.local/sitemap-fr.xml</loc></sitemap>
+</sitemapindex>`,
+            { status: 200, headers: { 'Content-Type': 'application/xml' } },
+          ),
+      ),
+      http.get(
+        'http://opt-sitemap-locale.local/sitemap-ja.xml',
+        () =>
+          new HttpResponse(
+            `<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>http://opt-sitemap-locale.local/ja/intro</loc></url>
+  <url><loc>http://opt-sitemap-locale.local/ja/guide</loc></url>
+</urlset>`,
+            { status: 200, headers: { 'Content-Type': 'application/xml' } },
+          ),
+      ),
+    );
+
+    const ctx = makeCtx('http://opt-sitemap-locale.local');
+    ctx.options.preferredLocale = 'ja';
+
+    const result = await getPageUrls(ctx);
+    expect(result.urls).toEqual([
+      'http://opt-sitemap-locale.local/ja/intro',
+      'http://opt-sitemap-locale.local/ja/guide',
+    ]);
+  });
+
+  it('skipRefinement returns unfiltered sitemap URLs', async () => {
+    server.use(
+      http.get('http://skip-refine.local/robots.txt', () => new HttpResponse('', { status: 404 })),
+      http.get(
+        'http://skip-refine.local/sitemap.xml',
+        () =>
+          new HttpResponse(
+            `<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>http://skip-refine.local/en/intro</loc></url>
+  <url><loc>http://skip-refine.local/fr/intro</loc></url>
+  <url><loc>http://skip-refine.local/de/intro</loc></url>
+  <url><loc>http://skip-refine.local/en/guide</loc></url>
+  <url><loc>http://skip-refine.local/fr/guide</loc></url>
+  <url><loc>http://skip-refine.local/de/guide</loc></url>
+</urlset>`,
+            { status: 200, headers: { 'Content-Type': 'application/xml' } },
+          ),
+      ),
+    );
+
+    const ctx = createContext('http://skip-refine.local', { requestDelay: 0 });
+    const warnings: string[] = [];
+
+    // Without skipRefinement: should filter to 'en' (2 URLs)
+    const refined = await getUrlsFromSitemap(ctx, warnings);
+    expect(refined).toHaveLength(2);
+    expect(refined.every((u) => u.includes('/en/'))).toBe(true);
+
+    // With skipRefinement: should return all 6 URLs
+    const raw = await getUrlsFromSitemap(ctx, warnings, { skipRefinement: true });
+    expect(raw).toHaveLength(6);
+  });
+
+  it('preferredLocale works when base URL has no locale segment', async () => {
+    const content = `# Docs\n## Links\n- [EN](http://no-locale-base.local/en/intro): EN\n- [FR](http://no-locale-base.local/fr/intro): FR\n- [DE](http://no-locale-base.local/de/intro): DE\n`;
+    // Base URL has no locale — without the flag, would default to 'en'
+    const ctx = makeCtx('http://no-locale-base.local', content);
+    ctx.options.preferredLocale = 'fr';
+
+    const result = await getPageUrls(ctx);
+    expect(result.urls).toEqual(['http://no-locale-base.local/fr/intro']);
+  });
+
+  it('preferredVersion is a no-op when it matches version in base URL', async () => {
+    const content = `# Docs\n## Links\n- [v1](http://ver-match.local/docs/v1/intro): v1\n- [v2](http://ver-match.local/docs/v2/intro): v2\n- [v3](http://ver-match.local/docs/v3/intro): v3\n- [v1 Guide](http://ver-match.local/docs/v1/guide): v1\n- [v2 Guide](http://ver-match.local/docs/v2/guide): v2\n- [v3 Guide](http://ver-match.local/docs/v3/guide): v3\n`;
+    // preferredVersion matches what's in the base URL — same result either way
+    const ctx = makeCtx('http://ver-match.local/docs/v2', content);
+    ctx.options.preferredVersion = 'v2';
+
+    const result = await getPageUrls(ctx);
+    expect(result.urls).toEqual([
+      'http://ver-match.local/docs/v2/intro',
+      'http://ver-match.local/docs/v2/guide',
+    ]);
+  });
+
+  it('respects maxUrls cap when following sitemap index sub-sitemaps', async () => {
+    server.use(
+      http.get('http://cap-index.local/robots.txt', () => new HttpResponse('', { status: 404 })),
+      http.get(
+        'http://cap-index.local/sitemap.xml',
+        () =>
+          new HttpResponse(
+            `<?xml version="1.0"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>http://cap-index.local/sitemap-1.xml</loc></sitemap>
+  <sitemap><loc>http://cap-index.local/sitemap-2.xml</loc></sitemap>
+</sitemapindex>`,
+            { status: 200, headers: { 'Content-Type': 'application/xml' } },
+          ),
+      ),
+      http.get(
+        'http://cap-index.local/sitemap-1.xml',
+        () =>
+          new HttpResponse(
+            `<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>http://cap-index.local/page-1</loc></url>
+  <url><loc>http://cap-index.local/page-2</loc></url>
+  <url><loc>http://cap-index.local/page-3</loc></url>
+</urlset>`,
+            { status: 200, headers: { 'Content-Type': 'application/xml' } },
+          ),
+      ),
+      http.get(
+        'http://cap-index.local/sitemap-2.xml',
+        () =>
+          new HttpResponse(
+            `<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>http://cap-index.local/page-4</loc></url>
+  <url><loc>http://cap-index.local/page-5</loc></url>
+</urlset>`,
+            { status: 200, headers: { 'Content-Type': 'application/xml' } },
+          ),
+      ),
+    );
+
+    const ctx = createContext('http://cap-index.local', { requestDelay: 0 });
+    const warnings: string[] = [];
+    const result = await getUrlsFromSitemap(ctx, warnings, { maxUrls: 4 });
+    expect(result).toHaveLength(4);
+    // First 3 from sitemap-1, then 1 from sitemap-2 before cap
+    expect(result).toEqual([
+      'http://cap-index.local/page-1',
+      'http://cap-index.local/page-2',
+      'http://cap-index.local/page-3',
+      'http://cap-index.local/page-4',
+    ]);
   });
 });
 

--- a/test/unit/helpers/get-page-urls.test.ts
+++ b/test/unit/helpers/get-page-urls.test.ts
@@ -332,6 +332,61 @@ describe('getPageUrls', () => {
     expect(result.urls).toHaveLength(MAX_SITEMAP_URLS);
   });
 
+  it('applies path-prefix filter before the sitemap URL cap (#31)', async () => {
+    // Simulate Django-like sitemap index: Greek sitemap comes first alphabetically,
+    // filling the cap before the English sitemap is reached. Without the fix,
+    // path-prefix filtering after the cap would discard all Greek URLs and return 0 matches.
+    const greekLocs = Array.from(
+      { length: MAX_SITEMAP_URLS },
+      (_, i) => `  <url><loc>http://cap-prefix.local/el/page/${i}</loc></url>`,
+    ).join('\n');
+    const englishLocs = Array.from(
+      { length: 50 },
+      (_, i) => `  <url><loc>http://cap-prefix.local/en/6.0/page/${i}</loc></url>`,
+    ).join('\n');
+
+    server.use(
+      http.get('http://cap-prefix.local/robots.txt', () => new HttpResponse('', { status: 404 })),
+      http.get(
+        'http://cap-prefix.local/sitemap.xml',
+        () =>
+          new HttpResponse(
+            `<?xml version="1.0"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>http://cap-prefix.local/sitemap-el.xml</loc></sitemap>
+  <sitemap><loc>http://cap-prefix.local/sitemap-en.xml</loc></sitemap>
+</sitemapindex>`,
+            { status: 200, headers: { 'Content-Type': 'application/xml' } },
+          ),
+      ),
+      http.get(
+        'http://cap-prefix.local/sitemap-el.xml',
+        () =>
+          new HttpResponse(
+            `<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${greekLocs}\n</urlset>`,
+            { status: 200, headers: { 'Content-Type': 'application/xml' } },
+          ),
+      ),
+      http.get(
+        'http://cap-prefix.local/sitemap-en.xml',
+        () =>
+          new HttpResponse(
+            `<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${englishLocs}\n</urlset>`,
+            { status: 200, headers: { 'Content-Type': 'application/xml' } },
+          ),
+      ),
+    );
+
+    // User wants to test /en/6.0/ docs specifically
+    const ctx = makeCtx('http://cap-prefix.local/en/6.0');
+    const result = await getPageUrls(ctx);
+
+    // With the fix: path filter is applied before the cap, so Greek URLs
+    // don't consume cap slots. All 50 English URLs should be found.
+    expect(result.urls.length).toBe(50);
+    expect(result.urls.every((u) => u.includes('/en/6.0/'))).toBe(true);
+  });
+
   it('handles sitemap fetch network errors gracefully', async () => {
     server.use(
       http.get('http://net-err.local/robots.txt', () => new HttpResponse('', { status: 404 })),


### PR DESCRIPTION
Fixes the following four issues identified when working on the agent docs report:
- #22 
- #30 
- #31 
- #32 

Adds two new flags, `--doc-locale` and `--doc-version`, to filter docs during URL discovery by locale and by version. 