### PR TITLE
fix: strip code blocks before HTML detection in looksLikeHtml()

### DIFF
--- a/src/helpers/detect-markdown.ts
+++ b/src/helpers/detect-markdown.ts
@@ -5,10 +5,25 @@ const MD_LINK = /\[[^\]]+\]\([^)]+\)/;
 const MD_CODE_FENCE = /^```/m;
 
 /**
+ * Strip fenced code blocks and inline code spans so that HTML tags mentioned
+ * inside code (e.g. `<body>` or a fenced HTML snippet) don't produce false
+ * positives when checking for HTML patterns.
+ */
+function stripCode(text: string): string {
+  // Strip fenced code blocks (``` or ~~~, with optional language tag)
+  text = text.replace(/^(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1[ \t]*$/gm, '');
+  // Strip inline code spans
+  text = text.replace(/`[^`\n]+`/g, '``');
+  return text;
+}
+
+/**
  * Returns true if the body looks like HTML (contains DOCTYPE, <html>, <head>, or <body> tags).
+ * Fenced code blocks and inline code spans are stripped first to avoid false positives
+ * from markdown that mentions HTML tags in code examples.
  */
 export function looksLikeHtml(body: string): boolean {
-  const sample = body.slice(0, 2000);
+  const sample = stripCode(body.slice(0, 2000));
   return HTML_PATTERNS.some((p) => p.test(sample));
 }
 

--- a/test/unit/helpers/detect-markdown.test.ts
+++ b/test/unit/helpers/detect-markdown.test.ts
@@ -26,6 +26,26 @@ describe('looksLikeHtml', () => {
   it('returns false for markdown', () => {
     expect(looksLikeHtml('# Hello\n\nThis is **markdown**.')).toBe(false);
   });
+
+  it('ignores HTML tags inside fenced code blocks', () => {
+    const md = '# Example\n\n```html\n<!DOCTYPE html>\n<html>\n<body>Hello</body>\n</html>\n```\n';
+    expect(looksLikeHtml(md)).toBe(false);
+  });
+
+  it('ignores HTML tags inside inline code spans', () => {
+    const md = '# Setup\n\nAdd the script before the closing `</body>` tag.\n';
+    expect(looksLikeHtml(md)).toBe(false);
+  });
+
+  it('ignores HTML tags inside tilde fenced code blocks', () => {
+    const md = '# Example\n\n~~~html\n<html>\n<head><title>Test</title></head>\n</html>\n~~~\n';
+    expect(looksLikeHtml(md)).toBe(false);
+  });
+
+  it('still detects real HTML outside of code blocks', () => {
+    const html = '<!DOCTYPE html>\n<html>\n```not a code block\n```\n</html>';
+    expect(looksLikeHtml(html)).toBe(true);
+  });
 });
 
 describe('looksLikeMarkdown', () => {
@@ -47,5 +67,11 @@ describe('looksLikeMarkdown', () => {
 
   it('returns false for plain text with no markdown signals', () => {
     expect(looksLikeMarkdown('Just some plain text without any formatting.')).toBe(false);
+  });
+
+  it('returns true for markdown containing HTML examples in code', () => {
+    const md =
+      '# Web API\n\nAdd the script before `</body>`.\n\n```html\n<html><body>Hello</body></html>\n```\n';
+    expect(looksLikeMarkdown(md)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
Fixes `looksLikeHtml()` false-positives on markdown pages that contain HTML tags inside fenced code blocks or inline code spans (e.g. `` `<body>` ``). This causes `content-negotiation` and `markdown-url-support` checks to misclassify valid markdown responses as HTML.

Some pages like:
- HTML: https://developers.cloudflare.com/zaraz/web-api/
- Markdown: https://developers.cloudflare.com/zaraz/web-api/index.md

include valid HTML elements in their markdown in code blocks.

<img width="770" height="503" alt="0" src="https://github.com/user-attachments/assets/ff43a53f-80a9-4cac-9e2d-6fe109578b9f" />
<img width="1405" height="210" alt="1" src="https://github.com/user-attachments/assets/b03031b7-18d7-45a1-ad9d-e1e3e98442e7" />

## Fix
Strip fenced code blocks and inline code spans from the sample before running HTML pattern matching.

## Tests
Added 5 new test cases covering fenced blocks (backtick and tilde), inline code spans, and ensuring real HTML outside code is still detected.