### PR TITLE
feat: add --skip-checks to exclude specific checks

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -64,14 +64,20 @@ See [Config File](/reference/config-file) for the full config format.
 
 ### Check selection
 
-| Flag                 | Default | Description                              |
-| -------------------- | ------- | ---------------------------------------- |
-| `-c, --checks <ids>` | all     | Comma-separated list of check IDs to run |
+| Flag                  | Default | Description                               |
+| --------------------- | ------- | ----------------------------------------- |
+| `-c, --checks <ids>`  | all     | Comma-separated list of check IDs to run  |
+| `--skip-checks <ids>` |         | Comma-separated list of check IDs to skip |
 
 ```bash
 # Run only llms.txt checks
 afdocs check https://docs.example.com --checks llms-txt-exists,llms-txt-valid,llms-txt-size
+
+# Run all checks except one
+afdocs check https://docs.example.com --skip-checks markdown-content-parity
 ```
+
+`--checks` is an include-list (only run these). `--skip-checks` is an exclude-list (run everything except these). Skipped checks appear in the report with `status: "skip"` and are excluded from scoring.
 
 Some checks depend on others. If you include a check without its dependency, the dependent check will be skipped. See [Check dependencies](/checks/#check-dependencies) for the full list.
 

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -19,6 +19,10 @@ checks:
   - http-status-codes
   - auth-gate-detection
 
+# Optional: skip specific checks (run everything else)
+# skipChecks:
+#   - markdown-content-parity
+
 # Optional: override default options
 options:
   maxLinksToTest: 20
@@ -50,6 +54,17 @@ The documentation site URL to check. This is the only required field.
 A list of check IDs to run. If omitted, all 22 checks run. Use this to focus on checks that are actionable for your platform. See the [Checks Reference](/checks/) for the full list of check IDs.
 
 This is particularly useful when your docs platform doesn't support certain capabilities. For example, if you can't serve markdown, exclude the markdown-related checks so your score reflects what you can control. See [Improve Your Score](/improve-your-score#step-3-work-through-fixes-iteratively) for more on this approach.
+
+### `skipChecks` (optional)
+
+A list of check IDs to skip. Unlike `checks` (which is an include-list), `skipChecks` is an exclude-list — all checks run except the ones listed here. Skipped checks appear in the report with `status: "skip"` and are excluded from scoring.
+
+Use this when you want to disable a specific check without having to list all the others:
+
+```yaml
+skipChecks:
+  - markdown-content-parity
+```
 
 ### `options` (optional)
 

--- a/docs/reference/programmatic-api.md
+++ b/docs/reference/programmatic-api.md
@@ -32,7 +32,8 @@ Pass a second argument to configure sampling, concurrency, and thresholds:
 import { runChecks } from 'afdocs';
 
 const report = await runChecks('https://docs.example.com', {
-  checkIds: ['llms-txt-exists', 'llms-txt-valid', 'llms-txt-size'],
+  checkIds: ['llms-txt-exists', 'llms-txt-valid', 'llms-txt-size'], // include-list
+  skipCheckIds: ['markdown-content-parity'], // exclude-list
   samplingStrategy: 'deterministic',
   maxLinksToTest: 20,
   maxConcurrency: 5,

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -19,6 +19,7 @@ export function registerCheckCommand(program: Command): void {
     .option('--config <path>', 'Path to config file (default: auto-discover agent-docs.config.yml)')
     .option('-f, --format <format>', 'Output format: text, json, or scorecard', 'text')
     .option('-c, --checks <checks>', 'Comma-separated list of check IDs to run')
+    .option('--skip-checks <checks>', 'Comma-separated list of check IDs to skip')
     .option('--max-concurrency <n>', 'Maximum concurrent requests')
     .option('--request-delay <ms>', 'Delay between requests in ms')
     .option('--max-links <n>', 'Maximum links to test')
@@ -109,6 +110,10 @@ export function registerCheckCommand(program: Command): void {
         ? (opts.checks as string).split(',').map((s) => s.trim())
         : config?.checks;
 
+      const skipCheckIds = opts.skipChecks
+        ? (opts.skipChecks as string).split(',').map((s) => s.trim())
+        : config?.skipChecks;
+
       const format = opts.format as string;
       if (!FORMAT_OPTIONS.includes(format as (typeof FORMAT_OPTIONS)[number])) {
         process.stderr.write(
@@ -196,6 +201,7 @@ export function registerCheckCommand(program: Command): void {
 
       const report = await runChecks(url, {
         checkIds,
+        skipCheckIds,
         maxConcurrency,
         requestDelay,
         maxLinksToTest,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -70,12 +70,27 @@ export async function runChecks(
   const ctx = createContext(baseUrl, options);
   const allChecks = getChecksSorted();
   const checkIds = options?.checkIds;
+  const skipCheckIds = options?.skipCheckIds ?? [];
 
   const results: CheckResult[] = [];
 
   for (const check of allChecks) {
     // Filter by requested check IDs if provided
     if (checkIds && checkIds.length > 0 && !checkIds.includes(check.id)) {
+      continue;
+    }
+
+    // Emit a skip result for explicitly excluded checks without running them.
+    // Intentionally not stored in previousResults so dependent checks see
+    // "dependency never ran" and can run in standalone mode — matching the
+    // behaviour of checks filtered out by checkIds.
+    if (skipCheckIds.includes(check.id)) {
+      results.push({
+        id: check.id,
+        category: check.category,
+        status: 'skip',
+        message: 'Check skipped (excluded via --skip-checks)',
+      });
       continue;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,6 +137,8 @@ export interface DiscoveredFile {
 export interface RunnerOptions extends CheckOptions {
   /** Only run checks matching these IDs. If empty, run all. */
   checkIds?: string[];
+  /** Skip checks matching these IDs, emitting a 'skip' result without running them. */
+  skipCheckIds?: string[];
   /** Curated page list from config or --urls. Used when samplingStrategy is 'curated'. */
   curatedPages?: PageConfigEntry[];
 }
@@ -163,6 +165,8 @@ export interface ReportResult {
 export interface AgentDocsConfig {
   url: string;
   checks?: string[];
+  /** Check IDs to skip, emitting a 'skip' result without running them. */
+  skipChecks?: string[];
   options?: Partial<CheckOptions>;
   /** Curated page URLs to test. Implies `samplingStrategy: 'curated'` when no strategy is set. */
   pages?: PageConfigEntry[];

--- a/test/unit/runner.test.ts
+++ b/test/unit/runner.test.ts
@@ -295,6 +295,68 @@ describe('runner', () => {
     expect(child?.status).toBe('pass');
   });
 
+  it('skips checks listed in skipCheckIds without running them', async () => {
+    server.use(
+      http.get('http://skip-ids.local/llms.txt', () => new HttpResponse(null, { status: 404 })),
+      http.get(
+        'http://skip-ids.local/docs/llms.txt',
+        () => new HttpResponse(null, { status: 404 }),
+      ),
+    );
+
+    const report = await runChecks('http://skip-ids.local', {
+      checkIds: ['llms-txt-exists', 'llms-txt-valid', 'llms-txt-size'],
+      skipCheckIds: ['llms-txt-valid'],
+      requestDelay: 0,
+    });
+
+    const skipped = report.results.find((r) => r.id === 'llms-txt-valid');
+    expect(skipped).toBeDefined();
+    expect(skipped?.status).toBe('skip');
+    expect(skipped?.message).toContain('--skip-checks');
+
+    // llms-txt-exists should still run (not in skipCheckIds)
+    const exists = report.results.find((r) => r.id === 'llms-txt-exists');
+    expect(exists).toBeDefined();
+    expect(exists?.status).toBe('fail');
+
+    // llms-txt-size depends on llms-txt-exists which failed, so it should be
+    // skipped due to dependency — not due to skipCheckIds
+    const size = report.results.find((r) => r.id === 'llms-txt-size');
+    expect(size).toBeDefined();
+    expect(size?.status).toBe('skip');
+    expect(size?.message).toContain('dependency');
+  });
+
+  it('skipCheckIds does not cascade-skip dependent checks', async () => {
+    const content = `# Test\n\n> Summary.\n\n## Links\n\n- [A](http://skip-dep.local/a): A\n`;
+    server.use(
+      http.get('http://skip-dep.local/llms.txt', () => HttpResponse.text(content)),
+      http.get(
+        'http://skip-dep.local/docs/llms.txt',
+        () => new HttpResponse(null, { status: 404 }),
+      ),
+    );
+
+    // Skip llms-txt-exists; llms-txt-valid depends on it.
+    // Since skipCheckIds doesn't store in previousResults, llms-txt-valid
+    // should run in standalone mode (same as checkIds filtering).
+    const report = await runChecks('http://skip-dep.local', {
+      checkIds: ['llms-txt-exists', 'llms-txt-valid'],
+      skipCheckIds: ['llms-txt-exists'],
+      requestDelay: 0,
+    });
+
+    const exists = report.results.find((r) => r.id === 'llms-txt-exists');
+    expect(exists?.status).toBe('skip');
+    expect(exists?.message).toContain('--skip-checks');
+
+    // llms-txt-valid should run in standalone mode, not cascade-skip
+    const valid = report.results.find((r) => r.id === 'llms-txt-valid');
+    expect(valid).toBeDefined();
+    expect(valid?.message).not.toContain('dependency');
+  });
+
   it('includes timestamp and url in report', async () => {
     server.use(
       http.get('http://meta.local/llms.txt', () => new HttpResponse(null, { status: 404 })),


### PR DESCRIPTION
Adds `skipCheckIds` as an exclude-list counterpart to the existing `checkIds` include-list. Useful when you want to disable one or two checks without enumerating all the others.

**Behaviour:**
- Skipped checks emit `status: "skip"` without running
- Excluded from scoring (matching existing skip handling)
- Does **not** cascade-skip dependent checks — dependents run in standalone mode, consistent with how `checkIds` filtering works

**Supported via:**
- **CLI:** `--skip-checks <ids>`
- **Config file:** `skipChecks: [...]`
- **Programmatic API:** `skipCheckIds` in `RunnerOptions`

```bash
# Disable a single check
afdocs check https://docs.example.com --skip-checks markdown-content-parity
```

```yaml
# agent-docs.config.yml
skipChecks:
  - markdown-content-parity
```

```ts
const report = await runChecks('https://docs.example.com', {
  skipCheckIds: ['markdown-content-parity'],
});
```