### PR TITLE
fix: address truncation risk in stripCode across slice boundaries

### DIFF
--- a/src/helpers/detect-markdown.ts
+++ b/src/helpers/detect-markdown.ts
@@ -23,7 +23,7 @@ function stripCode(text: string): string {
  * from markdown that mentions HTML tags in code examples.
  */
 export function looksLikeHtml(body: string): boolean {
-  const sample = stripCode(body.slice(0, 2000));
+  const sample = stripCode(body).slice(0, 2000);
   return HTML_PATTERNS.some((p) => p.test(sample));
 }
 

--- a/test/unit/helpers/detect-markdown.test.ts
+++ b/test/unit/helpers/detect-markdown.test.ts
@@ -42,6 +42,12 @@ describe('looksLikeHtml', () => {
     expect(looksLikeHtml(md)).toBe(false);
   });
 
+  it('ignores HTML in code blocks longer than 2000 characters', () => {
+    const md =
+      '# Setup\n\n```html\n<html>\n<body>\n' + 'x'.repeat(3000) + '\n</body>\n</html>\n```\n';
+    expect(looksLikeHtml(md)).toBe(false);
+  });
+
   it('still detects real HTML outside of code blocks', () => {
     const html = '<!DOCTYPE html>\n<html>\n```not a code block\n```\n</html>';
     expect(looksLikeHtml(html)).toBe(true);


### PR DESCRIPTION
Follow up to #42 - minor change to address truncation edge case where regex boundaries cross the slice range boundary.