### PR TITLE
fix: tests for normalize md URLs now test the curated path

### DIFF
--- a/test/unit/checks/content-negotiation.test.ts
+++ b/test/unit/checks/content-negotiation.test.ts
@@ -353,8 +353,8 @@ describe('content-negotiation', () => {
   });
 
   it('normalizes .md URLs to canonical form before testing (#33)', async () => {
-    // The handler is on the canonical (non-.md) URL because the check
-    // should strip the extension before fetching.
+    // Curated pages bypass discovery, so .md URLs reach the check directly.
+    // The check should strip the extension before fetching.
     server.use(
       http.get(
         'http://test.local/docs/page1',
@@ -366,8 +366,12 @@ describe('content-negotiation', () => {
       ),
     );
 
-    const content = `# Docs\n> Summary\n## Links\n- [Page 1](http://test.local/docs/page1.md): First\n`;
-    const result = await check.run(makeCtx(content));
+    const ctx = createContext('http://test.local', {
+      requestDelay: 0,
+      samplingStrategy: 'curated',
+      curatedPages: ['http://test.local/docs/page1.md'],
+    });
+    const result = await check.run(ctx);
 
     expect(result.status).toBe('fail');
     expect(result.details?.normalizedMdUrls).toBe(1);
@@ -377,6 +381,7 @@ describe('content-negotiation', () => {
   });
 
   it('reports testedUrl when .md URL is normalized (#33)', async () => {
+    // Curated pages bypass discovery, so .md URLs reach the check directly.
     server.use(
       http.get(
         'http://test.local/docs/page1',
@@ -388,8 +393,12 @@ describe('content-negotiation', () => {
       ),
     );
 
-    const content = `# Docs\n> Summary\n## Links\n- [Page 1](http://test.local/docs/page1.md): First\n`;
-    const result = await check.run(makeCtx(content));
+    const ctx = createContext('http://test.local', {
+      requestDelay: 0,
+      samplingStrategy: 'curated',
+      curatedPages: ['http://test.local/docs/page1.md'],
+    });
+    const result = await check.run(ctx);
 
     const pageResults = result.details?.pageResults as Array<{
       url: string;

--- a/test/unit/checks/llms-txt-directive.test.ts
+++ b/test/unit/checks/llms-txt-directive.test.ts
@@ -265,6 +265,8 @@ describe('llms-txt-directive', () => {
   });
 
   it('falls back to .md URL when HTML version has no directive', async () => {
+    // Curated pages bypass discovery, so .md URLs reach the check directly.
+    // The check should try the HTML version first, then fall back to the .md URL.
     server.use(
       http.get(
         'http://test.local/docs/page1/',
@@ -284,7 +286,12 @@ describe('llms-txt-directive', () => {
       ),
     );
 
-    const result = await check.run(makeCtx(llms('/docs/page1/index.md')));
+    const ctx = createContext('http://test.local', {
+      requestDelay: 0,
+      samplingStrategy: 'curated',
+      curatedPages: ['http://test.local/docs/page1/index.md'],
+    });
+    const result = await check.run(ctx);
     expect(result.status).toBe('pass');
     expect(result.details?.foundCount).toBe(1);
     const pages = result.details?.pageResults as Array<{ source?: string }>;


### PR DESCRIPTION
Follow up to #44 - these tests were failing after the markdown normalization moved upstream, so I've updated them to test the curated path, which doesn't use the same markdown URL normalization logic as the discover-and-sample path.