### PR TITLE
Strip 'style' and 'script' tags in HTML

### DIFF
--- a/src/checks/page-size/page-size-html.ts
+++ b/src/checks/page-size/page-size-html.ts
@@ -107,6 +107,9 @@ async function check(ctx: CheckContext): Promise<CheckResult> {
   const convertedSizes = successful.map((r) => r.convertedCharacters).sort((a, b) => a - b);
   const median = convertedSizes[Math.floor(convertedSizes.length / 2)];
   const max = convertedSizes[convertedSizes.length - 1];
+  const htmlSizes = successful.map((r) => r.htmlCharacters).sort((a, b) => a - b);
+  const medianHtml = htmlSizes[Math.floor(htmlSizes.length / 2)];
+  const maxHtml = htmlSizes[htmlSizes.length - 1];
   const avgRatio = Math.round(
     successful.reduce((sum, r) => sum + r.conversionRatio, 0) / successful.length,
   );
@@ -124,11 +127,11 @@ async function check(ctx: CheckContext): Promise<CheckResult> {
 
   let message: string;
   if (overallStatus === 'pass') {
-    message = `All ${successful.length} ${pageLabel} convert under ${formatSize(passThreshold)} chars (median ${formatSize(median)}, ${avgRatio}% boilerplate)${suffix}`;
+    message = `All ${successful.length} ${pageLabel} under ${formatSize(passThreshold)} chars (median ${formatSize(medianHtml)} HTML → ${formatSize(median)} markdown (${avgRatio}% boilerplate))${suffix}`;
   } else if (overallStatus === 'warn') {
-    message = `${warnBucket} of ${successful.length} ${pageLabel} convert to ${formatSize(passThreshold)}–${formatSize(failThreshold)} chars (max ${formatSize(max)}, ${avgRatio}% boilerplate)${suffix}`;
+    message = `${warnBucket} of ${successful.length} ${pageLabel} convert to ${formatSize(passThreshold)}–${formatSize(failThreshold)} chars (max ${formatSize(maxHtml)} HTML → ${formatSize(max)} markdown (${avgRatio}% boilerplate))${suffix}`;
   } else {
-    message = `${failBucket} of ${successful.length} ${pageLabel} convert to over ${formatSize(failThreshold)} chars (max ${formatSize(max)}, ${avgRatio}% boilerplate)${suffix}`;
+    message = `${failBucket} of ${successful.length} ${pageLabel} convert to over ${formatSize(failThreshold)} chars (max ${formatSize(maxHtml)} HTML → ${formatSize(max)} markdown (${avgRatio}% boilerplate))${suffix}`;
   }
 
   return {

--- a/src/helpers/html-to-markdown.ts
+++ b/src/helpers/html-to-markdown.ts
@@ -1,15 +1,13 @@
+import { parse } from 'node-html-parser';
 import TurndownService from 'turndown';
 import { tables } from 'turndown-plugin-gfm';
 
-/**
- * Convert HTML to markdown using Turndown with default configuration.
- * Matches real agent behavior per the Agent-Friendly Documentation Spec:
- * no explicit <style>/<script> stripping, default options only.
- * The GFM tables plugin is enabled so HTML tables are preserved as markdown
- * tables rather than being flattened to plain text.
- */
 export function htmlToMarkdown(html: string): string {
+  const root = parse(html);
+  for (const el of root.querySelectorAll('script, style')) {
+    el.remove();
+  }
   const turndown = new TurndownService();
   turndown.use(tables);
-  return turndown.turndown(html);
+  return turndown.turndown(root.toString());
 }

--- a/test/unit/checks/content-start-position.test.ts
+++ b/test/unit/checks/content-start-position.test.ts
@@ -270,12 +270,12 @@ describe('content-start-position', () => {
   // ── Status threshold: fail (>50%) ──
 
   it('fails when content starts past 50%', async () => {
-    // Massive CSS boilerplate (leaks through Turndown) before a tiny heading
-    const cssRules = Array.from(
-      { length: 200 },
-      (_, i) => `.class${i} { color: red; margin: ${i}px; }`,
-    ).join('\n');
-    const html = `<html><head><style>${cssRules}</style></head><body><h3>Tiny Content</h3></body></html>`;
+    // Massive nav boilerplate before a tiny content section
+    const navLinks = Array.from(
+      { length: 100 },
+      (_, i) => `<li><a href="/nav${i}">Navigation Link ${i}</a></li>`,
+    ).join('');
+    const html = `<html><body><nav><ul>${navLinks}</ul></nav><h3>Tiny Content</h3><p>A short paragraph of documentation.</p></body></html>`;
 
     server.use(
       http.get(
@@ -305,17 +305,17 @@ describe('content-start-position', () => {
       ),
     );
 
-    // Page 2: massive CSS boilerplate before content (fail)
-    const cssRules = Array.from(
-      { length: 200 },
-      (_, i) => `.c${i} { color: red; margin: ${i}px; }`,
-    ).join('\n');
+    // Page 2: massive nav boilerplate before content (fail)
+    const navLinks = Array.from(
+      { length: 100 },
+      (_, i) => `<li><a href="/nav${i}">Navigation Link ${i}</a></li>`,
+    ).join('');
     server.use(
       http.get(
         'http://test.local/docs/bad',
         () =>
           new HttpResponse(
-            `<html><head><style>${cssRules}</style></head><body><h3>Late Content</h3></body></html>`,
+            `<html><body><nav><ul>${navLinks}</ul></nav><h3>Late Content</h3><p>A short paragraph.</p></body></html>`,
             { status: 200, headers: { 'Content-Type': 'text/html' } },
           ),
       ),

--- a/test/unit/helpers/html-to-markdown.test.ts
+++ b/test/unit/helpers/html-to-markdown.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { htmlToMarkdown } from '../../../src/helpers/html-to-markdown.js';
+
+describe('htmlToMarkdown', () => {
+  it('converts basic HTML to markdown', () => {
+    const html = '<html><body><h1>Title</h1><p>Hello world.</p></body></html>';
+    const md = htmlToMarkdown(html);
+    expect(md).toContain('Title');
+    expect(md).toContain('Hello world.');
+  });
+
+  it('strips <script> elements and their contents', () => {
+    const html = `<html><body>
+      <script>const x = 42; console.log(x);</script>
+      <h1>Title</h1>
+      <script type="application/json">{"key": "value"}</script>
+      <p>Content.</p>
+    </body></html>`;
+    const md = htmlToMarkdown(html);
+    expect(md).toContain('Title');
+    expect(md).toContain('Content.');
+    expect(md).not.toContain('const x = 42');
+    expect(md).not.toContain('console.log');
+    expect(md).not.toContain('"key"');
+  });
+
+  it('strips <style> elements and their contents', () => {
+    const html = `<html><head>
+      <style>.nav { color: red; margin: 10px; font-size: 14px; }</style>
+    </head><body>
+      <h1>Title</h1>
+      <style>body { background: blue; }</style>
+      <p>Content.</p>
+    </body></html>`;
+    const md = htmlToMarkdown(html);
+    expect(md).toContain('Title');
+    expect(md).toContain('Content.');
+    expect(md).not.toContain('color: red');
+    expect(md).not.toContain('background: blue');
+    expect(md).not.toContain('.nav');
+  });
+
+  it('strips both <script> and <style> while preserving content', () => {
+    const css = Array.from({ length: 50 }, (_, i) => `.c${i} { color: red; }`).join('\n');
+    const js = 'function init() { document.getElementById("app").render(); }';
+    const html = `<html><head><style>${css}</style></head><body>
+      <script>${js}</script>
+      <h1>Documentation</h1>
+      <p>This is the real content.</p>
+    </body></html>`;
+    const md = htmlToMarkdown(html);
+    expect(md).toContain('Documentation');
+    expect(md).toContain('This is the real content.');
+    expect(md).not.toContain('color: red');
+    expect(md).not.toContain('document.getElementById');
+  });
+
+  it('preserves HTML tables as markdown tables', () => {
+    const html = `<table><tr><th>Name</th><th>Value</th></tr>
+      <tr><td>foo</td><td>bar</td></tr></table>`;
+    const md = htmlToMarkdown(html);
+    expect(md).toContain('Name');
+    expect(md).toContain('foo');
+    expect(md).toContain('|');
+  });
+});


### PR DESCRIPTION
## Summary

- Strip `<script>` and `<style>` elements before Turndown conversion in `htmlToMarkdown`, matching Claude Code's updated web fetch behavior (v2.1.105+) and the spec v0.4.0 pipeline-agnostic language for `page-size-html` and `content-start-position`.
- Update `page-size-html` message format to show the HTML→markdown conversion ratio (e.g., `496K HTML → 30K markdown (94% boilerplate)`) following the spec's recommended format, replacing the previous ambiguous `94% boilerplate` label.
- Update two `content-start-position` tests that relied on `<style>` content leaking through Turndown to use nav-link boilerplate instead.

Closes #34

## Before/after

Tested against `https://www.mongodb.com/docs/manual/crud/` with `--sampling none`:

| Check | Before | After |
|-------|--------|-------|
| `page-size-html` | FAIL — 324K chars, 35% boilerplate | PASS — 30K chars (496K HTML → 30K markdown, 94% boilerplate) |
| `content-start-position` | WARN — 41% | PASS — 1% |

## Test plan

- [x] New `html-to-markdown.test.ts` unit tests verify `<script>` and `<style>` stripping (5 tests)
- [x] Updated `content-start-position` tests use nav boilerplate instead of `<style>` CSS
- [x] Full test suite passes (885/885)