### PR TITLE
Single-page scoring reliability and run-level diagnostics

### DIFF
--- a/SCORING.md
+++ b/SCORING.md
@@ -121,7 +121,23 @@ For checks that test multiple pages (like `page-size-html` or `rendering-strateg
 score = (sum of check scores) / (sum of weights for non-skipped checks) × 100
 ```
 
-Rounded to the nearest integer.
+Rounded to the nearest integer. Checks marked as `notApplicable` (see below) are excluded from both numerator and denominator.
+
+### Insufficient-data handling (scoreDisplayMode)
+
+When the tool discovers only a single page using automatic discovery (`random` or `deterministic` sampling), page-level check scores are unreliable because they represent one page out of potentially thousands. In this case:
+
+- **Page-level checks** get `scoreDisplayMode: "notApplicable"` and are excluded from the overall score calculation.
+- **Site-level checks** (llms.txt checks, coverage, auth-alternative-access) remain `scoreDisplayMode: "numeric"` and are scored normally.
+- **Category scores** where all checks are `notApplicable` become `null` and render as a dash in the scorecard.
+- **Categories with a mix** of page-level and site-level checks score based on the site-level checks only.
+
+This follows the Lighthouse convention: don't present a number when the data behind it isn't meaningful.
+
+This behavior does **not** apply when:
+
+- `--sampling curated` or `--urls`: the user explicitly chose pages to test.
+- `--sampling none`: the user opted out of sampling entirely.
 
 ### Warn coefficients
 
@@ -154,6 +170,8 @@ Some problems are severe enough that no amount of other good behavior should com
 | `no-viable-path` diagnostic fires (see below)      | 39 (F) | Agents have no effective way to access content at all.                         |
 
 When multiple caps apply, the lowest one wins.
+
+The `rendering-strategy` and `auth-gate-detection` caps do not apply when the check has `scoreDisplayMode: "notApplicable"` (insufficient data). If we don't trust the data enough to include it in the score, we don't trust it enough to cap the score either.
 
 ## Interaction diagnostics
 
@@ -216,6 +234,38 @@ Some problems only become visible when you look at multiple checks together. The
 **What it means**: Agents will silently receive truncated content on oversized pages, with no alternative path to the full content.
 
 **What to do**: Either reduce HTML page sizes (break large pages, reduce inline CSS/JS) or provide markdown versions and make them discoverable.
+
+### Single-page sample
+
+**Triggers when** automatic discovery (`random` or `deterministic` sampling) found only one page to test.
+
+**What it means**: Page-level category scores (page size, content structure, URL stability, etc.) are based on a single page and may not represent the site. These categories are marked as N/A in the score.
+
+**What to do**: If your site has an llms.txt, ensure it contains working links so the tool can discover more pages. If testing a preview deployment, use `--canonical-origin` to rewrite cross-origin llms.txt links. You can also provide specific pages with `--urls`.
+
+### All llms.txt links are cross-origin
+
+**Triggers when** every link in your llms.txt points to a different origin than the one being tested.
+
+**What it means**: This typically happens when testing a preview or staging deployment whose llms.txt still references the production domain. The tool filters cross-origin links during page discovery, so it falls back to testing a single page.
+
+**What to do**: Use `--canonical-origin <production-origin>` to rewrite cross-origin links during testing.
+
+### Gzipped sitemap skipped
+
+**Triggers when** a gzipped sitemap (e.g. `sitemap.xml.gz`) was encountered during URL discovery and skipped because gzipped sitemaps are not yet supported.
+
+**What it means**: If the gzipped sitemap is the only sitemap source, URL discovery may have found fewer pages than expected.
+
+**What to do**: Provide an uncompressed `sitemap.xml` alongside the gzipped version, or supply specific pages via `--urls`.
+
+### Severe rate limiting
+
+**Triggers when** more than 20% of tested URLs returned HTTP 429 (Too Many Requests).
+
+**What it means**: The target site is rate-limiting requests from the tool. Check results may be unreliable because rate-limited requests are not retried indefinitely.
+
+**What to do**: Increase `--request-delay` to slow down requests, or contact the site operator to allowlist your IP or user-agent for testing.
 
 ## Cluster coefficients
 

--- a/SCORING.md
+++ b/SCORING.md
@@ -125,7 +125,7 @@ Rounded to the nearest integer. Checks marked as `notApplicable` (see below) are
 
 ### Insufficient-data handling (scoreDisplayMode)
 
-When the tool discovers only a single page using automatic discovery (`random` or `deterministic` sampling), page-level check scores are unreliable because they represent one page out of potentially thousands. In this case:
+When automatic discovery (`random` or `deterministic` sampling) finds fewer than 5 pages, page-level check scores are unreliable because they represent a handful of pages out of potentially thousands. In this case:
 
 - **Page-level checks** get `scoreDisplayMode: "notApplicable"` and are excluded from the overall score calculation.
 - **Site-level checks** (llms.txt checks, coverage, auth-alternative-access) remain `scoreDisplayMode: "numeric"` and are scored normally.
@@ -237,9 +237,9 @@ Some problems only become visible when you look at multiple checks together. The
 
 ### Single-page sample
 
-**Triggers when** automatic discovery (`random` or `deterministic` sampling) found only one page to test.
+**Triggers when** automatic discovery (`random` or `deterministic` sampling) found fewer than 5 pages to test.
 
-**What it means**: Page-level category scores (page size, content structure, URL stability, etc.) are based on a single page and may not represent the site. These categories are marked as N/A in the score.
+**What it means**: Page-level category scores (page size, content structure, URL stability, etc.) are based on too few pages to be representative. These categories are marked as N/A in the score.
 
 **What to do**: If your site has an llms.txt, ensure it contains working links so the tool can discover more pages. If testing a preview deployment, use `--canonical-origin` to rewrite cross-origin llms.txt links. You can also provide specific pages with `--urls`.
 

--- a/docs/agent-score-calculation.md
+++ b/docs/agent-score-calculation.md
@@ -162,7 +162,7 @@ The `rendering-strategy` and `auth-gate-detection` caps do not apply when the ch
 
 ## Insufficient data
 
-When automatic page discovery finds only a single page (using `random` or `deterministic` sampling), page-level check scores are unreliable because they represent one page out of potentially thousands. In this case:
+When automatic page discovery finds fewer than 5 pages (using `random` or `deterministic` sampling), page-level check scores are unreliable because they represent a handful of pages out of potentially thousands. In this case:
 
 - **Page-level checks** (those that test sampled pages like `page-size-html`, `rendering-strategy`, `http-status-codes`, etc.) are marked as "not applicable" and excluded from the score.
 - **Site-level checks** (llms.txt checks, coverage, auth-alternative-access) are scored normally.
@@ -170,7 +170,7 @@ When automatic page discovery finds only a single page (using `random` or `deter
 
 This typically happens when a site has no llms.txt or its llms.txt links point to a different origin (common with preview deployments). A [`single-page-sample` diagnostic](/interaction-diagnostics#single-page-sample) fires to explain the situation.
 
-This behavior does not apply when you explicitly choose pages with `--urls` or `--sampling curated`, or when you use `--sampling none`. If you intentionally test a single page, the score reflects that page.
+This behavior does not apply when you explicitly choose pages with `--urls` or `--sampling curated`, or when you use `--sampling none`. If you intentionally select pages, the score reflects those pages regardless of count.
 
 ## Cluster coefficients
 

--- a/docs/agent-score-calculation.md
+++ b/docs/agent-score-calculation.md
@@ -16,6 +16,7 @@ Each check earns a proportion of its weight based on its result:
 - **Warn**: Partial weight (see [warn coefficients](#warn-coefficients) below)
 - **Fail**: Zero
 - **Skip**: Excluded from both the numerator and denominator
+- **Not applicable**: Excluded (see [insufficient data](#insufficient-data) below)
 
 The score is rounded to the nearest integer and mapped to a [letter grade](/what-is-agent-score#letter-grades).
 
@@ -156,6 +157,20 @@ Some problems are severe enough that no amount of other passing checks should co
 | [No viable path](/interaction-diagnostics#no-viable-path-to-content) diagnostic fires | 39 (F) | Agents have no effective way to access content at all. |
 
 When multiple caps apply, the lowest one wins.
+
+The `rendering-strategy` and `auth-gate-detection` caps do not apply when the check is marked as not applicable due to [insufficient data](#insufficient-data). If there isn't enough data to include the check in the score, there isn't enough data to cap the score based on it either.
+
+## Insufficient data
+
+When automatic page discovery finds only a single page (using `random` or `deterministic` sampling), page-level check scores are unreliable because they represent one page out of potentially thousands. In this case:
+
+- **Page-level checks** (those that test sampled pages like `page-size-html`, `rendering-strategy`, `http-status-codes`, etc.) are marked as "not applicable" and excluded from the score.
+- **Site-level checks** (llms.txt checks, coverage, auth-alternative-access) are scored normally.
+- **Category scores** where all checks are not applicable display as a dash instead of a number.
+
+This typically happens when a site has no llms.txt or its llms.txt links point to a different origin (common with preview deployments). A [`single-page-sample` diagnostic](/interaction-diagnostics#single-page-sample) fires to explain the situation.
+
+This behavior does not apply when you explicitly choose pages with `--urls` or `--sampling curated`, or when you use `--sampling none`. If you intentionally test a single page, the score reflects that page.
 
 ## Cluster coefficients
 

--- a/docs/interaction-diagnostics.md
+++ b/docs/interaction-diagnostics.md
@@ -73,3 +73,45 @@ These diagnostics appear in the "Interaction Diagnostics" section of the `--form
 **What to do**: Either reduce HTML page sizes (break large pages into smaller ones, move inline CSS/JS to external files) or provide markdown versions and make them discoverable via content negotiation or llms.txt links. See [Page Size checks](/checks/page-size) for the specific thresholds.
 
 **Score impact**: No direct score cap, but the combination of failing page-size checks with no markdown alternative typically results in low category scores for both Page Size and Markdown Availability.
+
+## Single-page sample
+
+**Triggers when** automatic page discovery (`random` or `deterministic` sampling) found only one page to test.
+
+**What it means**: Page-level category scores (Page Size, Content Structure, URL Stability, etc.) are based on a single page and may not represent the site. These categories are marked as N/A in the score rather than showing potentially misleading numbers.
+
+**What to do**: If your site has an llms.txt, ensure it contains working links so the tool can discover more pages. If testing a preview deployment, use `--canonical-origin` to rewrite cross-origin llms.txt links. You can also provide specific pages with `--urls` to test exactly the pages you care about.
+
+This diagnostic does not fire when you explicitly choose pages with `--urls`, `--sampling curated`, or `--sampling none`.
+
+**Score impact**: Page-level checks are excluded from the overall score and their categories show as N/A. Only site-level checks (llms.txt checks, coverage, auth-alternative-access) contribute to the score.
+
+## All llms.txt links are cross-origin
+
+**Triggers when** every link in your llms.txt points to a different origin than the one being tested.
+
+**What it means**: This typically happens when testing a preview or staging deployment whose llms.txt still references the production domain. The tool filters cross-origin links during page discovery, so it falls back to testing a single page. You'll usually see this alongside the [single-page sample](#single-page-sample) diagnostic.
+
+**What to do**: Use `--canonical-origin <production-origin>` to rewrite cross-origin links during testing. For example: `npx afdocs check https://preview.example.com --canonical-origin https://docs.example.com`.
+
+**Score impact**: Indirect. By reducing discovered pages to one, it triggers the single-page sample behavior described above.
+
+## Gzipped sitemap skipped
+
+**Triggers when** a gzipped sitemap (e.g. `sitemap.xml.gz`) was encountered during URL discovery and skipped because gzipped sitemaps are not yet supported.
+
+**What it means**: If the gzipped sitemap is the only sitemap source, URL discovery may have found fewer pages than expected. This can reduce the representativeness of page-level check results.
+
+**What to do**: Provide an uncompressed `sitemap.xml` alongside the gzipped version, or supply specific pages via `--urls` for targeted testing.
+
+**Score impact**: No direct score impact, but fewer discovered pages may reduce the representativeness of results.
+
+## Severe rate limiting
+
+**Triggers when** more than 20% of tested URLs returned HTTP 429 (Too Many Requests) across all checks that make HTTP requests.
+
+**What it means**: The target site is rate-limiting requests from the tool. Check results may be unreliable because rate-limited requests are not retried indefinitely, so some pages may not have been fully tested.
+
+**What to do**: Increase `--request-delay` to slow down requests (the default is 200ms), or contact the site operator to allowlist your IP or user-agent for testing.
+
+**Score impact**: No direct score impact, but rate-limited requests may cause checks to report incomplete data, leading to scores that don't reflect the site's actual state.

--- a/docs/interaction-diagnostics.md
+++ b/docs/interaction-diagnostics.md
@@ -76,9 +76,9 @@ These diagnostics appear in the "Interaction Diagnostics" section of the `--form
 
 ## Single-page sample
 
-**Triggers when** automatic page discovery (`random` or `deterministic` sampling) found only one page to test.
+**Triggers when** automatic page discovery (`random` or `deterministic` sampling) found fewer than 5 pages to test.
 
-**What it means**: Page-level category scores (Page Size, Content Structure, URL Stability, etc.) are based on a single page and may not represent the site. These categories are marked as N/A in the score rather than showing potentially misleading numbers.
+**What it means**: Page-level category scores (Page Size, Content Structure, URL Stability, etc.) are based on too few pages to be representative. These categories are marked as N/A in the score rather than showing potentially misleading numbers.
 
 **What to do**: If your site has an llms.txt, ensure it contains working links so the tool can discover more pages. If testing a preview deployment, use `--canonical-origin` to rewrite cross-origin llms.txt links. You can also provide specific pages with `--urls` to test exactly the pages you care about.
 

--- a/docs/reference/programmatic-api.md
+++ b/docs/reference/programmatic-api.md
@@ -23,6 +23,8 @@ for (const result of report.results) {
 - `timestamp` — when the check ran
 - `results` — array of `CheckResult` objects (one per check)
 - `summary` — counts by status (pass, warn, fail, skip, error)
+- `testedPages` — number of pages tested by page-level checks (present when page discovery ran)
+- `samplingStrategy` — the sampling strategy used (`random`, `deterministic`, `curated`, or `none`)
 
 ## Run with options
 
@@ -104,6 +106,7 @@ import type {
   ReportResult,
   RunnerOptions,
   CheckOptions,
+  SamplingStrategy, // 'random' | 'deterministic' | 'curated' | 'none'
   AgentDocsConfig,
   CuratedPageEntry,
   PageConfigEntry,

--- a/docs/reference/scoring-api.md
+++ b/docs/reference/scoring-api.md
@@ -12,7 +12,9 @@ const score = computeScore(report);
 
 console.log(score.overall); // 72
 console.log(score.grade); // 'C'
-console.log(score.categoryScores); // { 'content-discoverability': { score: 80, grade: 'B' }, ... }
+console.log(score.categoryScores);
+// { 'content-discoverability': { score: 80, grade: 'B' }, ... }
+// Categories may have null score/grade when all checks lack sufficient data
 console.log(score.diagnostics); // [{ id: 'markdown-undiscoverable', severity: 'warning', ... }]
 console.log(score.resolutions); // { 'llms-txt-directive-html': 'Add a visually-hidden element...' }
 ```
@@ -33,16 +35,18 @@ This is the same function; the subpath is provided for consumers who want a narr
 
 `computeScore` returns a `ScoreResult` with these fields:
 
-| Field            | Type                            | Description                                                               |
-| ---------------- | ------------------------------- | ------------------------------------------------------------------------- |
-| `overall`        | `number`                        | The overall score (0-100)                                                 |
-| `grade`          | `Grade`                         | Letter grade (`A+`, `A`, `B`, `C`, `D`, `F`)                              |
-| `categoryScores` | `Record<string, CategoryScore>` | Per-category score and grade                                              |
-| `checkScores`    | `Record<string, CheckScore>`    | Per-check scoring details (weight, coefficient, proportion, earned score) |
-| `diagnostics`    | `Diagnostic[]`                  | Interaction diagnostics that fired                                        |
-| `caps`           | `ScoreCap[]`                    | Score caps that were applied                                              |
-| `resolutions`    | `Record<string, string>`        | Fix suggestions keyed by check ID                                         |
-| `tagScores`      | `Record<string, TagScore>`      | Per-tag aggregate scores (present when curated pages have tags)           |
+| Field            | Type                            | Description                                                                                                                           |
+| ---------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `overall`        | `number`                        | The overall score (0-100)                                                                                                             |
+| `grade`          | `Grade`                         | Letter grade (`A+`, `A`, `B`, `C`, `D`, `F`)                                                                                          |
+| `categoryScores` | `Record<string, CategoryScore>` | Per-category score and grade. `score` and `grade` are `null` when all checks in the category are `notApplicable` (insufficient data). |
+| `checkScores`    | `Record<string, CheckScore>`    | Per-check scoring details (weight, coefficient, proportion, earned score, scoreDisplayMode)                                           |
+| `diagnostics`    | `Diagnostic[]`                  | Interaction diagnostics that fired                                                                                                    |
+| `cap`            | `ScoreCap`                      | Score cap that was applied (present only when a cap reduced the score)                                                                |
+| `resolutions`    | `Record<string, string>`        | Fix suggestions keyed by check ID                                                                                                     |
+| `tagScores`      | `Record<string, TagScore>`      | Per-tag aggregate scores (present when curated pages have tags)                                                                       |
+
+Each `CheckScore` includes a `scoreDisplayMode` field (`"numeric"` or `"notApplicable"`). When automatic page discovery finds only one page, page-level checks are marked `"notApplicable"` and excluded from overall and category score calculations. See [Insufficient data](/agent-score-calculation#insufficient-data) for details.
 
 ## TagScore
 
@@ -105,6 +109,7 @@ import type {
   Diagnostic,
   DiagnosticSeverity, // 'info' | 'warning' | 'critical'
   Grade, // 'A+' | 'A' | 'B' | 'C' | 'D' | 'F'
+  ScoreDisplayMode, // 'numeric' | 'notApplicable'
 } from 'afdocs';
 ```
 

--- a/docs/reference/scoring-api.md
+++ b/docs/reference/scoring-api.md
@@ -46,7 +46,7 @@ This is the same function; the subpath is provided for consumers who want a narr
 | `resolutions`    | `Record<string, string>`        | Fix suggestions keyed by check ID                                                                                                     |
 | `tagScores`      | `Record<string, TagScore>`      | Per-tag aggregate scores (present when curated pages have tags)                                                                       |
 
-Each `CheckScore` includes a `scoreDisplayMode` field (`"numeric"` or `"notApplicable"`). When automatic page discovery finds only one page, page-level checks are marked `"notApplicable"` and excluded from overall and category score calculations. See [Insufficient data](/agent-score-calculation#insufficient-data) for details.
+Each `CheckScore` includes a `scoreDisplayMode` field (`"numeric"` or `"notApplicable"`). When automatic page discovery finds fewer than 5 pages, page-level checks are marked `"notApplicable"` and excluded from overall and category score calculations. See [Insufficient data](/agent-score-calculation#insufficient-data) for details.
 
 ## TagScore
 

--- a/docs/what-is-agent-score.md
+++ b/docs/what-is-agent-score.md
@@ -79,7 +79,7 @@ Agent-Friendly Docs Scorecard
             Fix: Add a blockquote near the top of each page ...
 ```
 
-The [Interaction Diagnostics](/interaction-diagnostics) section covers amplification effects between checks. When some check failures compound, the agent impact is more pronounced than individual check failures imply. This includes things like having markdown support that agents can't discover, or page sizes that exceed limits with no alternate format available.
+The [Interaction Diagnostics](/interaction-diagnostics) section covers amplification effects between checks. When some check failures compound, the agent impact is more pronounced than individual check failures imply. This includes things like having markdown support that agents can't discover, page sizes that exceed limits with no alternate format available, or the tool discovering only a single page to test (which causes page-level categories to display as N/A rather than showing potentially misleading scores).
 
 ## What to do with your score
 

--- a/scoring-reference.md
+++ b/scoring-reference.md
@@ -193,12 +193,45 @@ same destination are deduplicated before scoring (e.g., if `/docs/llms.txt`
 ### Overall Score
 
 ```
-score = (sum of check_scores for non-skipped checks)
-      / (sum of weights for non-skipped checks)
+score = (sum of check_scores for non-skipped, non-N/A checks)
+      / (sum of weights for non-skipped, non-N/A checks)
       * 100
 ```
 
 Rounded to the nearest integer.
+
+### Score Display Mode (Insufficient Data)
+
+Each `CheckScore` has a `scoreDisplayMode` field:
+
+- `"numeric"` (default): normal scored result.
+- `"notApplicable"`: insufficient data to score meaningfully. The check ran
+  but its score is excluded from the overall and category calculations.
+
+The `notApplicable` mode triggers when all of:
+
+- `samplingStrategy` is `random` or `deterministic` (discovery-based).
+- `testedPages` equals 1.
+- The check is page-level (tests sampled pages, not site-level resources).
+
+Page-level checks: `llms-txt-directive-html`, `llms-txt-directive-md`,
+`markdown-url-support`, `content-negotiation`, `markdown-code-fence-validity`,
+`page-size-markdown`, `page-size-html`, `markdown-content-parity`,
+`content-start-position`, `tabbed-content-serialization`,
+`section-header-quality`, `http-status-codes`, `redirect-behavior`,
+`rendering-strategy`, `auth-gate-detection`, `cache-header-hygiene`.
+
+Site-level checks (always `numeric`): `llms-txt-exists`, `llms-txt-valid`,
+`llms-txt-size`, `llms-txt-links-resolve`, `llms-txt-links-markdown`,
+`llms-txt-coverage`, `auth-alternative-access`.
+
+**Category scores**: When all scored checks in a category are `notApplicable`,
+the category score is `null` (rendered as a dash in the scorecard). Mixed
+categories (some N/A, some numeric) score based on numeric checks only.
+
+**ReportResult fields**: `testedPages` (number of pages tested by page-level
+checks) and `samplingStrategy` (the strategy used for this run) are added to
+`ReportResult` so the scoring layer can detect the insufficient-data condition.
 
 ### Critical Check Score Caps
 
@@ -213,6 +246,8 @@ or its **status** (for single-resource checks):
 For each critical check:
   if single-resource AND status == fail:
     apply cap (total failure)
+  if multi-page AND scoreDisplayMode == 'notApplicable':
+    skip (insufficient data to justify a cap)
   if multi-page AND proportion <= 0.25 (75%+ of pages fail):
     cap overall score at 39 (F)
   if multi-page AND proportion <= 0.50 (50%+ of pages fail):
@@ -515,6 +550,54 @@ in dependency order: `markdown-undiscoverable` and
 - **Resolution**: Either reduce HTML page sizes (break large pages, reduce
   inline CSS/JS), or provide markdown versions and ensure agents can discover
   them via content negotiation or an llms.txt directive.
+
+#### `single-page-sample`
+
+- **Severity**: warning
+- **Triggers when**: `samplingStrategy` is `random` or `deterministic` AND
+  `testedPages` equals 1.
+- **Message**: Only one page was discovered and tested. Page-level category
+  scores are based on a single page and may not represent the site. These
+  categories are marked as N/A in the score.
+- **Resolution**: If your site has an llms.txt, ensure it contains working
+  links so the tool can discover more pages. If testing a preview deployment,
+  use --canonical-origin to rewrite cross-origin llms.txt links. You can also
+  provide specific pages with --urls.
+
+#### `cross-origin-llms-txt`
+
+- **Severity**: warning
+- **Triggers when**: `llms-txt-links-resolve` ran AND its details show
+  `sameOrigin.total === 0` AND `crossOrigin.total > 0`.
+- **Message**: All {n} links in your llms.txt point to {dominant_origin}, not
+  the origin being tested. This typically happens when testing a preview or
+  staging deployment whose llms.txt still references the production domain.
+  Page discovery falls back to a single page.
+- **Resolution**: Use --canonical-origin <production-origin> to rewrite
+  cross-origin links during testing.
+
+#### `gzipped-sitemap-skipped`
+
+- **Severity**: info
+- **Triggers when**: Any check's `details.discoveryWarnings` array contains
+  a string matching "gzipped sitemap".
+- **Message**: A gzipped sitemap was skipped during URL discovery. If this
+  is the only sitemap source, it may have reduced the number of pages
+  discovered for testing.
+- **Resolution**: Provide an uncompressed sitemap.xml alongside the gzipped
+  version, or supply specific pages via --urls for targeted testing.
+
+#### `rate-limiting-severe`
+
+- **Severity**: warning
+- **Triggers when**: Across all checks that report `details.rateLimited`,
+  the total rate-limited count exceeds 20% of the total tested count
+  (derived from `details.testedLinks` or `details.pageResults.length`).
+- **Message**: {pct}% of tested URLs returned HTTP 429 (rate limited). Check
+  results may be unreliable because rate-limited requests are not retried
+  indefinitely.
+- **Resolution**: Increase --request-delay to slow down requests, or contact
+  the site operator to allowlist your IP or user-agent for testing.
 
 ---
 

--- a/scoring-reference.md
+++ b/scoring-reference.md
@@ -211,7 +211,7 @@ Each `CheckScore` has a `scoreDisplayMode` field:
 The `notApplicable` mode triggers when all of:
 
 - `samplingStrategy` is `random` or `deterministic` (discovery-based).
-- `testedPages` equals 1.
+- `testedPages` is less than `MIN_PAGES_FOR_SCORING` (default 5).
 - The check is page-level (tests sampled pages, not site-level resources).
 
 Page-level checks: `llms-txt-directive-html`, `llms-txt-directive-md`,
@@ -555,10 +555,10 @@ in dependency order: `markdown-undiscoverable` and
 
 - **Severity**: warning
 - **Triggers when**: `samplingStrategy` is `random` or `deterministic` AND
-  `testedPages` equals 1.
-- **Message**: Only one page was discovered and tested. Page-level category
-  scores are based on a single page and may not represent the site. These
-  categories are marked as N/A in the score.
+  `testedPages` is less than `MIN_PAGES_FOR_SCORING` (default 5).
+- **Message**: Only {n} page(s) discovered and tested (minimum 5 needed for
+  reliable scoring). Page-level category scores may not represent the site.
+  These categories are marked as N/A in the score.
 - **Resolution**: If your site has an llms.txt, ensure it contains working
   links so the tool can discover more pages. If testing a preview deployment,
   use --canonical-origin to rewrite cross-origin llms.txt links. You can also

--- a/src/checks/content-discoverability/llms-txt-links-resolve.ts
+++ b/src/checks/content-discoverability/llms-txt-links-resolve.ts
@@ -152,6 +152,27 @@ async function checkLlmsTxtLinksResolve(ctx: CheckContext): Promise<CheckResult>
       ? ` (${crossBroken.length} external link${crossBroken.length === 1 ? '' : 's'} also failed; may be bot-detection or rate-limiting)`
       : '';
 
+  // Find the most common cross-origin domain for diagnostics
+  let dominantCrossOrigin: string | null = null;
+  if (crossOriginLinks.length > 0) {
+    const originCounts = new Map<string, number>();
+    for (const url of crossOriginLinks) {
+      try {
+        const o = new URL(url).origin;
+        originCounts.set(o, (originCounts.get(o) ?? 0) + 1);
+      } catch {
+        // skip unparseable
+      }
+    }
+    let maxCount = 0;
+    for (const [origin, count] of originCounts) {
+      if (count > maxCount) {
+        maxCount = count;
+        dominantCrossOrigin = origin;
+      }
+    }
+  }
+
   const details: Record<string, unknown> = {
     totalLinks,
     sameOrigin: {
@@ -171,6 +192,7 @@ async function checkLlmsTxtLinksResolve(ctx: CheckContext): Promise<CheckResult>
       broken: crossBroken.map((b) => ({ url: b.url, status: b.status, error: b.error })),
       fetchErrors: crossFetchErrors,
       rateLimited: crossRateLimited,
+      dominantOrigin: dominantCrossOrigin,
     },
     // Flat fields kept for backward compatibility
     testedLinks: sameResults.length + crossResults.length,

--- a/src/cli/formatters/scorecard.ts
+++ b/src/cli/formatters/scorecard.ts
@@ -45,10 +45,13 @@ function formatLocalTime(iso: string): string {
   return d.toLocaleString();
 }
 
-function formatCategoryLine(name: string, score: number, grade: string): string {
+function formatCategoryLine(name: string, score: number | null, grade: string | null): string {
   const paddedName = name.padEnd(36);
+  if (score === null) {
+    return `    ${paddedName} ${chalk.dim('–'.padStart(9))} ${chalk.dim('(N/A)')}`;
+  }
   const scoreStr = `${score} / 100`;
-  const coloredGrade = gradeColor(grade)(`(${grade})`);
+  const coloredGrade = gradeColor(grade!)(`(${grade})`);
   return `    ${paddedName} ${scoreStr.padStart(9)} ${coloredGrade}`;
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,5 +40,8 @@ export const DEFAULT_COVERAGE_PASS_THRESHOLD = 95;
 /** Default llms-txt-coverage warn threshold (percentage). */
 export const DEFAULT_COVERAGE_WARN_THRESHOLD = 80;
 
+/** Minimum discovered pages before page-level scores are considered meaningful. */
+export const MIN_PAGES_FOR_SCORING = 5;
+
 /** Base URL for the Agent-Friendly Documentation Spec. */
 export const SPEC_BASE_URL = 'https://agentdocsspec.com/spec/';

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export type {
   AgentDocsConfig,
   DiscoveredFile,
   SizeThresholds,
+  SamplingStrategy,
   CuratedPageEntry,
   PageConfigEntry,
 } from './types.js';
@@ -32,4 +33,5 @@ export type {
   Diagnostic,
   DiagnosticSeverity,
   Grade,
+  ScoreDisplayMode,
 } from './scoring/types.js';

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -154,6 +154,7 @@ export async function runChecks(
 
   const urlTags = ctx._sampledPages?.urlTags;
   const discoverySources = ctx._sampledPages?.sources;
+  const testedPages = ctx._sampledPages?.urls.length;
 
   return {
     url: baseUrl,
@@ -163,5 +164,7 @@ export async function runChecks(
     summary,
     ...(urlTags && { urlTags }),
     ...(discoverySources && { discoverySources }),
+    ...(testedPages !== undefined && { testedPages }),
+    samplingStrategy: ctx.options.samplingStrategy,
   };
 }

--- a/src/scoring/diagnostics.ts
+++ b/src/scoring/diagnostics.ts
@@ -1,5 +1,6 @@
 import type { CheckResult, ReportResult } from '../types.js';
 import type { Diagnostic, DiagnosticSeverity } from './types.js';
+import { MIN_PAGES_FOR_SCORING } from '../constants.js';
 
 interface DiagnosticDefinition {
   id: string;
@@ -262,13 +263,22 @@ const DIAGNOSTIC_DEFINITIONS: DiagnosticDefinition[] = [
     triggers: (_results, _triggered, report) => {
       const isDiscoveryBased =
         report.samplingStrategy === 'random' || report.samplingStrategy === 'deterministic';
-      return isDiscoveryBased && report.testedPages === 1;
+      return (
+        isDiscoveryBased &&
+        report.testedPages !== undefined &&
+        report.testedPages < MIN_PAGES_FOR_SCORING
+      );
     },
-    message: () =>
-      'Only one page was discovered and tested. Page-level category scores ' +
-      '(page size, content structure, URL stability, etc.) are based on a ' +
-      'single page and may not represent the site. These categories are ' +
-      'marked as N/A in the score.',
+    message: (_results, _triggered, report) => {
+      const n = report.testedPages ?? 0;
+      const pageWord = n === 1 ? 'page was' : 'pages were';
+      return (
+        `Only ${n} ${pageWord} discovered and tested (minimum ${MIN_PAGES_FOR_SCORING} ` +
+        'needed for reliable scoring). Page-level category scores (page size, ' +
+        'content structure, URL stability, etc.) may not represent the site. ' +
+        'These categories are marked as N/A in the score.'
+      );
+    },
     resolution:
       'If your site has an llms.txt, ensure it contains working links so ' +
       'the tool can discover more pages. If testing a preview deployment, ' +

--- a/src/scoring/diagnostics.ts
+++ b/src/scoring/diagnostics.ts
@@ -1,12 +1,20 @@
-import type { CheckResult } from '../types.js';
+import type { CheckResult, ReportResult } from '../types.js';
 import type { Diagnostic, DiagnosticSeverity } from './types.js';
 
 interface DiagnosticDefinition {
   id: string;
   severity: DiagnosticSeverity;
   /** Evaluated in dependency order. Can reference prior diagnostic results. */
-  triggers: (results: Map<string, CheckResult>, triggered: Set<string>) => boolean;
-  message: (results: Map<string, CheckResult>, triggered: Set<string>) => string;
+  triggers: (
+    results: Map<string, CheckResult>,
+    triggered: Set<string>,
+    report: ReportResult,
+  ) => boolean;
+  message: (
+    results: Map<string, CheckResult>,
+    triggered: Set<string>,
+    report: ReportResult,
+  ) => string;
   resolution: string;
 }
 
@@ -245,23 +253,157 @@ const DIAGNOSTIC_DEFINITIONS: DiagnosticDefinition[] = [
       'CSS/JS), or provide markdown versions and ensure agents can discover ' +
       'them via content negotiation or an llms.txt directive.',
   },
+
+  // --- run-level diagnostics (don't depend on other diagnostics) ---
+
+  {
+    id: 'single-page-sample',
+    severity: 'warning',
+    triggers: (_results, _triggered, report) => {
+      const isDiscoveryBased =
+        report.samplingStrategy === 'random' || report.samplingStrategy === 'deterministic';
+      return isDiscoveryBased && report.testedPages === 1;
+    },
+    message: () =>
+      'Only one page was discovered and tested. Page-level category scores ' +
+      '(page size, content structure, URL stability, etc.) are based on a ' +
+      'single page and may not represent the site. These categories are ' +
+      'marked as N/A in the score.',
+    resolution:
+      'If your site has an llms.txt, ensure it contains working links so ' +
+      'the tool can discover more pages. If testing a preview deployment, ' +
+      'use --canonical-origin to rewrite cross-origin llms.txt links. You ' +
+      'can also provide specific pages with --urls.',
+  },
+
+  {
+    id: 'cross-origin-llms-txt',
+    severity: 'warning',
+    triggers: (results) => {
+      const linkResolve = results.get('llms-txt-links-resolve');
+      if (!linkResolve || linkResolve.status === 'skip') return false;
+      const d = linkResolve.details;
+      if (!d) return false;
+      const sameOrigin = d.sameOrigin as { total?: number } | undefined;
+      const crossOrigin = d.crossOrigin as { total?: number } | undefined;
+      return (sameOrigin?.total ?? 0) === 0 && (crossOrigin?.total ?? 0) > 0;
+    },
+    message: (results) => {
+      const d = results.get('llms-txt-links-resolve')?.details;
+      const crossOrigin = d?.crossOrigin as { total?: number; dominantOrigin?: string } | undefined;
+      const total = crossOrigin?.total ?? 0;
+      const dominant = crossOrigin?.dominantOrigin ?? 'an external origin';
+      return (
+        `All ${total} links in your llms.txt point to ${dominant}, not ` +
+        'the origin being tested. This typically happens when testing a ' +
+        'preview or staging deployment whose llms.txt still references the ' +
+        'production domain. Page discovery falls back to a single page.'
+      );
+    },
+    resolution:
+      'Use --canonical-origin <production-origin> to rewrite cross-origin ' +
+      'links during testing. For example: --canonical-origin https://docs.example.com',
+  },
+
+  {
+    id: 'gzipped-sitemap-skipped',
+    severity: 'info',
+    triggers: (results) => {
+      for (const result of results.values()) {
+        const warnings = result.details?.discoveryWarnings as string[] | undefined;
+        if (warnings?.some((w) => w.includes('gzipped sitemap'))) return true;
+      }
+      return false;
+    },
+    message: (results) => {
+      const urls: string[] = [];
+      for (const result of results.values()) {
+        const warnings = result.details?.discoveryWarnings as string[] | undefined;
+        if (!warnings) continue;
+        for (const w of warnings) {
+          if (w.includes('gzipped sitemap')) {
+            const match = w.match(/:\s*(.+)$/);
+            if (match) urls.push(match[1]);
+          }
+        }
+      }
+      const urlNote = urls.length > 0 ? ` (${urls.join(', ')})` : '';
+      return (
+        `A gzipped sitemap was skipped during URL discovery${urlNote}. ` +
+        'If this is the only sitemap source, it may have reduced the number ' +
+        'of pages discovered for testing.'
+      );
+    },
+    resolution:
+      'Provide an uncompressed sitemap.xml alongside the gzipped version, ' +
+      'or supply specific pages via --urls for targeted testing.',
+  },
+
+  {
+    id: 'rate-limiting-severe',
+    severity: 'warning',
+    triggers: (results) => {
+      let totalTested = 0;
+      let totalRateLimited = 0;
+      for (const result of results.values()) {
+        const d = result.details;
+        if (!d) continue;
+        const rl = d.rateLimited as number | undefined;
+        if (rl === undefined) continue;
+
+        const pageResults = d.pageResults as unknown[] | undefined;
+        const testedLinks = d.testedLinks as number | undefined;
+        const tested = testedLinks ?? pageResults?.length ?? 0;
+
+        totalTested += tested;
+        totalRateLimited += rl;
+      }
+      return totalTested > 0 && totalRateLimited / totalTested > 0.2;
+    },
+    message: (results) => {
+      let totalTested = 0;
+      let totalRateLimited = 0;
+      for (const result of results.values()) {
+        const d = result.details;
+        if (!d) continue;
+        const rl = d.rateLimited as number | undefined;
+        if (rl === undefined) continue;
+        const pageResults = d.pageResults as unknown[] | undefined;
+        const testedLinks = d.testedLinks as number | undefined;
+        totalTested += testedLinks ?? pageResults?.length ?? 0;
+        totalRateLimited += rl;
+      }
+      const pct = totalTested > 0 ? Math.round((totalRateLimited / totalTested) * 100) : 0;
+      return (
+        `${pct}% of tested URLs returned HTTP 429 (rate limited). Check ` +
+        'results may be unreliable because rate-limited requests are not ' +
+        'retried indefinitely.'
+      );
+    },
+    resolution:
+      'Increase --request-delay to slow down requests, or contact the site ' +
+      'operator to allowlist your IP or user-agent for testing.',
+  },
 ];
 
 /**
  * Evaluate all interaction diagnostics against a set of check results.
  * Returns triggered diagnostics in evaluation order.
  */
-export function evaluateDiagnostics(results: Map<string, CheckResult>): Diagnostic[] {
+export function evaluateDiagnostics(
+  results: Map<string, CheckResult>,
+  report: ReportResult,
+): Diagnostic[] {
   const triggered = new Set<string>();
   const diagnostics: Diagnostic[] = [];
 
   for (const def of DIAGNOSTIC_DEFINITIONS) {
-    if (def.triggers(results, triggered)) {
+    if (def.triggers(results, triggered, report)) {
       triggered.add(def.id);
       diagnostics.push({
         id: def.id,
         severity: def.severity,
-        message: def.message(results, triggered),
+        message: def.message(results, triggered, report),
         resolution: def.resolution,
       });
     }

--- a/src/scoring/index.ts
+++ b/src/scoring/index.ts
@@ -17,4 +17,5 @@ export type {
   Diagnostic,
   DiagnosticSeverity,
   Grade,
+  ScoreDisplayMode,
 } from './types.js';

--- a/src/scoring/score.ts
+++ b/src/scoring/score.ts
@@ -1,5 +1,5 @@
 import type { CheckResult, ReportResult } from '../types.js';
-import { CATEGORIES } from '../constants.js';
+import { CATEGORIES, MIN_PAGES_FOR_SCORING } from '../constants.js';
 import type { CategoryScore, CheckScore, Grade, ScoreCap, ScoreResult } from './types.js';
 import { getCheckWeight } from './weights.js';
 import { getCheckProportion } from './proportions.js';
@@ -42,7 +42,10 @@ export function computeScore(report: ReportResult): ScoreResult {
   // Determine if page-level scores lack meaningful data
   const isDiscoveryBased =
     report.samplingStrategy === 'random' || report.samplingStrategy === 'deterministic';
-  const insufficientData = isDiscoveryBased && report.testedPages === 1;
+  const insufficientData =
+    isDiscoveryBased &&
+    report.testedPages !== undefined &&
+    report.testedPages < MIN_PAGES_FOR_SCORING;
 
   // Compute per-check scores
   const checkScores: Record<string, CheckScore> = {};

--- a/src/scoring/score.ts
+++ b/src/scoring/score.ts
@@ -1,12 +1,31 @@
 import type { CheckResult, ReportResult } from '../types.js';
 import { CATEGORIES } from '../constants.js';
-import type { CheckScore, Grade, ScoreCap, ScoreResult } from './types.js';
+import type { CategoryScore, CheckScore, Grade, ScoreCap, ScoreResult } from './types.js';
 import { getCheckWeight } from './weights.js';
 import { getCheckProportion } from './proportions.js';
 import { getCoefficient } from './coefficients.js';
 import { evaluateDiagnostics } from './diagnostics.js';
 import { getResolution } from './resolutions.js';
 import { computeTagScores } from './tag-scores.js';
+
+const PAGE_LEVEL_CHECKS = new Set([
+  'llms-txt-directive-html',
+  'llms-txt-directive-md',
+  'markdown-url-support',
+  'content-negotiation',
+  'markdown-code-fence-validity',
+  'page-size-markdown',
+  'page-size-html',
+  'markdown-content-parity',
+  'content-start-position',
+  'tabbed-content-serialization',
+  'section-header-quality',
+  'http-status-codes',
+  'redirect-behavior',
+  'rendering-strategy',
+  'auth-gate-detection',
+  'cache-header-hygiene',
+]);
 
 /**
  * Compute a score from a report result.
@@ -19,6 +38,11 @@ export function computeScore(report: ReportResult): ScoreResult {
   for (const r of report.results) {
     resultMap.set(r.id, r);
   }
+
+  // Determine if page-level scores lack meaningful data
+  const isDiscoveryBased =
+    report.samplingStrategy === 'random' || report.samplingStrategy === 'deterministic';
+  const insufficientData = isDiscoveryBased && report.testedPages === 1;
 
   // Compute per-check scores
   const checkScores: Record<string, CheckScore> = {};
@@ -36,6 +60,7 @@ export function computeScore(report: ReportResult): ScoreResult {
     const coefficient = getCoefficient(result.id, resultMap);
     const effectiveWeight = weight.weight * coefficient;
     const earnedScore = proportionResult.proportion * effectiveWeight;
+    const isNotApplicable = insufficientData && PAGE_LEVEL_CHECKS.has(result.id);
 
     checkScores[result.id] = {
       baseWeight: weight.weight,
@@ -44,14 +69,16 @@ export function computeScore(report: ReportResult): ScoreResult {
       proportion: proportionResult.proportion,
       earnedScore,
       maxScore: effectiveWeight,
+      scoreDisplayMode: isNotApplicable ? 'notApplicable' : 'numeric',
     };
   }
 
-  // Overall score
+  // Overall score (exclude notApplicable checks)
   let totalEarned = 0;
   let totalMax = 0;
 
   for (const cs of Object.values(checkScores)) {
+    if (cs.scoreDisplayMode === 'notApplicable') continue;
     totalEarned += cs.earnedScore;
     totalMax += cs.maxScore;
   }
@@ -59,7 +86,7 @@ export function computeScore(report: ReportResult): ScoreResult {
   const rawScore = totalMax > 0 ? (totalEarned / totalMax) * 100 : 0;
 
   // Diagnostics (evaluated before caps so no-viable-path can trigger a cap)
-  const diagnostics = evaluateDiagnostics(resultMap);
+  const diagnostics = evaluateDiagnostics(resultMap, report);
   const triggeredDiagnostics = new Set(diagnostics.map((d) => d.id));
 
   // Apply critical check caps
@@ -67,24 +94,33 @@ export function computeScore(report: ReportResult): ScoreResult {
   const overall = Math.round(cap ? Math.min(rawScore, cap.cap) : rawScore);
 
   // Category scores
-  const categoryScores: Record<string, { score: number; grade: Grade }> = {};
+  const categoryScores: Record<string, CategoryScore> = {};
 
   for (const cat of CATEGORIES) {
     let catEarned = 0;
     let catMax = 0;
+    let hasNumericCheck = false;
+    let hasScoredCheck = false;
 
     for (const result of report.results) {
       if (result.category !== cat.id) continue;
       const cs = checkScores[result.id];
       if (!cs) continue;
+      hasScoredCheck = true;
+      if (cs.scoreDisplayMode === 'notApplicable') continue;
+      hasNumericCheck = true;
       catEarned += cs.earnedScore;
       catMax += cs.maxScore;
     }
 
-    categoryScores[cat.id] = {
-      score: catMax > 0 ? Math.round((catEarned / catMax) * 100) : 0,
-      grade: toGrade(catMax > 0 ? Math.round((catEarned / catMax) * 100) : 0),
-    };
+    if (hasScoredCheck && !hasNumericCheck) {
+      categoryScores[cat.id] = { score: null, grade: null };
+    } else {
+      categoryScores[cat.id] = {
+        score: catMax > 0 ? Math.round((catEarned / catMax) * 100) : 0,
+        grade: toGrade(catMax > 0 ? Math.round((catEarned / catMax) * 100) : 0),
+      };
+    }
   }
 
   // Resolutions
@@ -139,9 +175,10 @@ function computeCap(
   }
 
   // Multi-page critical checks: rendering-strategy, auth-gate-detection
+  // Skip N/A checks — insufficient data to justify a cap.
   for (const checkId of ['rendering-strategy', 'auth-gate-detection']) {
     const cs = checkScores[checkId];
-    if (!cs) continue;
+    if (!cs || cs.scoreDisplayMode === 'notApplicable') continue;
 
     if (cs.proportion <= 0.25) {
       caps.push({

--- a/src/scoring/types.ts
+++ b/src/scoring/types.ts
@@ -2,6 +2,8 @@ export type Grade = 'A+' | 'A' | 'B' | 'C' | 'D' | 'F';
 
 export type DiagnosticSeverity = 'critical' | 'warning' | 'info';
 
+export type ScoreDisplayMode = 'numeric' | 'notApplicable';
+
 export interface CheckScore {
   /** Base weight from the tier assignment. */
   baseWeight: number;
@@ -15,11 +17,13 @@ export interface CheckScore {
   earnedScore: number;
   /** effectiveWeight (the maximum this check could earn). */
   maxScore: number;
+  /** Whether this score is meaningful. 'notApplicable' when insufficient data. */
+  scoreDisplayMode: ScoreDisplayMode;
 }
 
 export interface CategoryScore {
-  score: number;
-  grade: Grade;
+  score: number | null;
+  grade: Grade | null;
 }
 
 export interface TagCheckBreakdown {

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,6 +176,10 @@ export interface ReportResult {
   urlTags?: Record<string, string>;
   /** Which discovery methods contributed to the page URL set. */
   discoverySources?: DiscoverySource[];
+  /** Number of pages tested by page-level checks. */
+  testedPages?: number;
+  /** The sampling strategy used for this run. */
+  samplingStrategy?: SamplingStrategy;
 }
 
 export interface AgentDocsConfig {

--- a/test/unit/cli/scorecard-formatter.test.ts
+++ b/test/unit/cli/scorecard-formatter.test.ts
@@ -48,6 +48,7 @@ function makeScoreResult(overrides?: Partial<ScoreResult>): ScoreResult {
         proportion: 1,
         earnedScore: 10,
         maxScore: 10,
+        scoreDisplayMode: 'numeric',
       },
       'llms-txt-valid': {
         baseWeight: 4,
@@ -56,6 +57,7 @@ function makeScoreResult(overrides?: Partial<ScoreResult>): ScoreResult {
         proportion: 0.75,
         earnedScore: 3,
         maxScore: 4,
+        scoreDisplayMode: 'numeric',
       },
       'markdown-url-support': {
         baseWeight: 7,
@@ -64,6 +66,7 @@ function makeScoreResult(overrides?: Partial<ScoreResult>): ScoreResult {
         proportion: 0,
         earnedScore: 0,
         maxScore: 7,
+        scoreDisplayMode: 'numeric',
       },
     },
     diagnostics: [],
@@ -411,5 +414,57 @@ describe('formatScorecard', () => {
   it('omits tag scores section when not present', () => {
     const output = formatScorecard(makeReport(), makeScoreResult());
     expect(output).not.toContain('Tag Scores:');
+  });
+
+  it('renders null category scores as N/A dash', () => {
+    const score = makeScoreResult({
+      categoryScores: {
+        'content-discoverability': { score: 80, grade: 'B' },
+        'markdown-availability': { score: null, grade: null },
+        'page-size': { score: null, grade: null },
+        'url-stability': { score: null, grade: null },
+      },
+    });
+    const output = formatScorecard(makeReport(), score);
+    expect(output).toContain('Content Discoverability');
+    expect(output).toContain('80 / 100');
+    expect(output).toContain('(N/A)');
+    // Should not show a numeric score for null categories
+    expect(output).not.toContain('null / 100');
+  });
+
+  it('renders N/A scorecard end-to-end from single-page discovery report', () => {
+    const report = makeReport({
+      results: [
+        {
+          id: 'llms-txt-exists',
+          category: 'content-discoverability',
+          status: 'fail',
+          message: 'No llms.txt found',
+        },
+        {
+          id: 'page-size-html',
+          category: 'page-size',
+          status: 'pass',
+          message: '1 page tested, all pass',
+        },
+        {
+          id: 'http-status-codes',
+          category: 'url-stability',
+          status: 'pass',
+          message: '1 page tested',
+        },
+      ],
+      summary: { total: 3, pass: 2, warn: 0, fail: 1, skip: 0, error: 0 },
+      testedPages: 1,
+      samplingStrategy: 'random',
+    });
+    // Let computeScore handle it (no pre-built scoreResult)
+    const output = formatScorecard(report);
+    // Page-level categories should show as N/A
+    expect(output).toContain('(N/A)');
+    // Should fire the single-page-sample diagnostic
+    expect(output).toContain('Interaction Diagnostics');
+    expect(output).toContain('Only one page was discovered');
   });
 });

--- a/test/unit/cli/scorecard-formatter.test.ts
+++ b/test/unit/cli/scorecard-formatter.test.ts
@@ -465,6 +465,6 @@ describe('formatScorecard', () => {
     expect(output).toContain('(N/A)');
     // Should fire the single-page-sample diagnostic
     expect(output).toContain('Interaction Diagnostics');
-    expect(output).toContain('Only one page was discovered');
+    expect(output).toContain('Only 1 page was discovered');
   });
 });

--- a/test/unit/scoring/diagnostics.test.ts
+++ b/test/unit/scoring/diagnostics.test.ts
@@ -356,10 +356,19 @@ describe('diagnostics', () => {
       expect(diags.find((d) => d.id === 'single-page-sample')).toBeUndefined();
     });
 
-    it('does not trigger when testedPages > 1', () => {
+    it('does not trigger when testedPages >= threshold', () => {
       const report = { ...defaultReport(), testedPages: 5, samplingStrategy: 'random' as const };
       const diags = evaluateDiagnostics(resultsMap(), report);
       expect(diags.find((d) => d.id === 'single-page-sample')).toBeUndefined();
+    });
+
+    it('triggers when testedPages is below threshold but above 1', () => {
+      const report = { ...defaultReport(), testedPages: 3, samplingStrategy: 'random' as const };
+      const diags = evaluateDiagnostics(resultsMap(), report);
+      const diag = diags.find((d) => d.id === 'single-page-sample');
+      expect(diag).toBeDefined();
+      expect(diag!.message).toContain('3 pages were');
+      expect(diag!.message).toContain('minimum 5');
     });
 
     it('does not trigger when testedPages is undefined', () => {

--- a/test/unit/scoring/diagnostics.test.ts
+++ b/test/unit/scoring/diagnostics.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { evaluateDiagnostics } from '../../../src/scoring/diagnostics.js';
-import type { CheckResult } from '../../../src/types.js';
+import type { CheckResult, ReportResult } from '../../../src/types.js';
 
 function r(
   id: string,
@@ -14,6 +14,18 @@ function resultsMap(...results: CheckResult[]): Map<string, CheckResult> {
   return new Map(results.map((res) => [res.id, res]));
 }
 
+function defaultReport(): ReportResult {
+  return {
+    url: 'https://example.com',
+    timestamp: new Date().toISOString(),
+    specUrl: 'https://agentdocsspec.com/spec/',
+    results: [],
+    summary: { total: 0, pass: 0, warn: 0, fail: 0, skip: 0, error: 0 },
+    samplingStrategy: 'random',
+    testedPages: 10,
+  };
+}
+
 describe('diagnostics', () => {
   describe('markdown-undiscoverable', () => {
     it('triggers when markdown supported but no directive and no content negotiation', () => {
@@ -22,7 +34,7 @@ describe('diagnostics', () => {
         r('content-negotiation', 'fail'),
         r('llms-txt-directive-html', 'fail'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       expect(diags.find((d) => d.id === 'markdown-undiscoverable')).toBeDefined();
     });
 
@@ -32,7 +44,7 @@ describe('diagnostics', () => {
         r('content-negotiation', 'fail'),
         r('llms-txt-directive-html', 'pass'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       expect(diags.find((d) => d.id === 'markdown-undiscoverable')).toBeUndefined();
     });
 
@@ -42,7 +54,7 @@ describe('diagnostics', () => {
         r('content-negotiation', 'pass'),
         r('llms-txt-directive-html', 'fail'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       expect(diags.find((d) => d.id === 'markdown-undiscoverable')).toBeUndefined();
       expect(diags.find((d) => d.id === 'markdown-partially-discoverable')).toBeDefined();
     });
@@ -53,7 +65,7 @@ describe('diagnostics', () => {
         r('content-negotiation', 'fail'),
         r('llms-txt-directive-html', 'fail'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       expect(diags.find((d) => d.id === 'markdown-undiscoverable')).toBeUndefined();
     });
   });
@@ -65,7 +77,7 @@ describe('diagnostics', () => {
         r('content-negotiation', 'pass'),
         r('llms-txt-directive-html', 'fail'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       const diag = diags.find((d) => d.id === 'markdown-partially-discoverable');
       expect(diag).toBeDefined();
       expect(diag!.severity).toBe('warning');
@@ -77,7 +89,7 @@ describe('diagnostics', () => {
         r('content-negotiation', 'pass'),
         r('llms-txt-directive-html', 'pass'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       expect(diags.find((d) => d.id === 'markdown-partially-discoverable')).toBeUndefined();
     });
 
@@ -87,7 +99,7 @@ describe('diagnostics', () => {
         r('content-negotiation', 'fail'),
         r('llms-txt-directive-html', 'fail'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       expect(diags.find((d) => d.id === 'markdown-partially-discoverable')).toBeUndefined();
       expect(diags.find((d) => d.id === 'markdown-undiscoverable')).toBeDefined();
     });
@@ -101,7 +113,7 @@ describe('diagnostics', () => {
           sizes: [{ characters: 250_000 }],
         }),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       const diag = diags.find((d) => d.id === 'truncated-index');
       expect(diag).toBeDefined();
       expect(diag!.message).toContain('250,000');
@@ -110,7 +122,7 @@ describe('diagnostics', () => {
 
     it('does not trigger when llms.txt is absent', () => {
       const results = resultsMap(r('llms-txt-exists', 'fail'), r('llms-txt-size', 'fail'));
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       expect(diags.find((d) => d.id === 'truncated-index')).toBeUndefined();
     });
   });
@@ -124,7 +136,7 @@ describe('diagnostics', () => {
           spaShells: 15,
         }),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       expect(diags.find((d) => d.id === 'spa-shell-html-invalid')).toBeDefined();
     });
 
@@ -136,7 +148,7 @@ describe('diagnostics', () => {
           spaShells: 0,
         }),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       expect(diags.find((d) => d.id === 'spa-shell-html-invalid')).toBeUndefined();
     });
 
@@ -149,7 +161,7 @@ describe('diagnostics', () => {
         }),
         r('markdown-url-support', 'pass'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       const diag = diags.find((d) => d.id === 'spa-shell-html-invalid');
       expect(diag!.message).toContain('markdown path still works');
     });
@@ -170,7 +182,7 @@ describe('diagnostics', () => {
         r('llms-txt-directive-md', 'fail'),
         r('llms-txt-links-markdown', 'fail'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       expect(diags.find((d) => d.id === 'no-viable-path')).toBeDefined();
       expect(diags.find((d) => d.id === 'no-viable-path')!.severity).toBe('critical');
     });
@@ -181,7 +193,7 @@ describe('diagnostics', () => {
         r('rendering-strategy', 'fail'),
         r('markdown-url-support', 'fail'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       expect(diags.find((d) => d.id === 'no-viable-path')).toBeDefined();
     });
 
@@ -192,7 +204,7 @@ describe('diagnostics', () => {
         r('rendering-strategy', 'fail'),
         r('markdown-url-support', 'fail'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       expect(diags.find((d) => d.id === 'no-viable-path')).toBeUndefined();
     });
 
@@ -207,7 +219,7 @@ describe('diagnostics', () => {
         }),
         r('markdown-url-support', 'fail'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       const diag = diags.find((d) => d.id === 'no-viable-path');
       expect(diag).toBeDefined();
       expect(diag!.message).toContain('0% of links resolve');
@@ -225,7 +237,7 @@ describe('diagnostics', () => {
         r('content-negotiation', 'pass'),
         r('llms-txt-directive-html', 'fail'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       expect(diags.find((d) => d.id === 'markdown-partially-discoverable')).toBeDefined();
       expect(diags.find((d) => d.id === 'no-viable-path')).toBeDefined();
     });
@@ -237,7 +249,7 @@ describe('diagnostics', () => {
         r('rendering-strategy', 'fail'),
         r('markdown-url-support', 'fail'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       expect(diags.find((d) => d.id === 'no-viable-path')).toBeUndefined();
     });
   });
@@ -248,7 +260,7 @@ describe('diagnostics', () => {
         r('auth-gate-detection', 'fail'),
         r('auth-alternative-access', 'fail'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       const diag = diags.find((d) => d.id === 'auth-no-alternative');
       expect(diag).toBeDefined();
       expect(diag!.severity).toBe('critical');
@@ -259,7 +271,7 @@ describe('diagnostics', () => {
         r('auth-gate-detection', 'fail'),
         r('auth-alternative-access', 'pass'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       expect(diags.find((d) => d.id === 'auth-no-alternative')).toBeUndefined();
     });
   });
@@ -270,7 +282,7 @@ describe('diagnostics', () => {
         r('page-size-html', 'fail', { failBucket: 12 }),
         r('markdown-url-support', 'fail'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       const diag = diags.find((d) => d.id === 'page-size-no-markdown-escape');
       expect(diag).toBeDefined();
       expect(diag!.message).toContain('12 pages');
@@ -285,7 +297,7 @@ describe('diagnostics', () => {
         r('llms-txt-directive-md', 'fail'),
         r('llms-txt-links-markdown', 'fail'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       expect(diags.find((d) => d.id === 'page-size-no-markdown-escape')).toBeDefined();
     });
 
@@ -296,7 +308,7 @@ describe('diagnostics', () => {
         r('content-negotiation', 'pass'),
         r('llms-txt-directive-html', 'fail'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       expect(diags.find((d) => d.id === 'page-size-no-markdown-escape')).toBeDefined();
     });
 
@@ -306,8 +318,181 @@ describe('diagnostics', () => {
         r('markdown-url-support', 'pass'),
         r('llms-txt-directive-html', 'pass'),
       );
-      const diags = evaluateDiagnostics(results);
+      const diags = evaluateDiagnostics(results, defaultReport());
       expect(diags.find((d) => d.id === 'page-size-no-markdown-escape')).toBeUndefined();
+    });
+  });
+
+  // --- New diagnostics ---
+
+  describe('single-page-sample', () => {
+    it('triggers when testedPages is 1 and strategy is discovery-based', () => {
+      const report = { ...defaultReport(), testedPages: 1, samplingStrategy: 'random' as const };
+      const diags = evaluateDiagnostics(resultsMap(), report);
+      const diag = diags.find((d) => d.id === 'single-page-sample');
+      expect(diag).toBeDefined();
+      expect(diag!.severity).toBe('warning');
+    });
+
+    it('triggers with deterministic sampling', () => {
+      const report = {
+        ...defaultReport(),
+        testedPages: 1,
+        samplingStrategy: 'deterministic' as const,
+      };
+      const diags = evaluateDiagnostics(resultsMap(), report);
+      expect(diags.find((d) => d.id === 'single-page-sample')).toBeDefined();
+    });
+
+    it('does not trigger with curated sampling', () => {
+      const report = { ...defaultReport(), testedPages: 1, samplingStrategy: 'curated' as const };
+      const diags = evaluateDiagnostics(resultsMap(), report);
+      expect(diags.find((d) => d.id === 'single-page-sample')).toBeUndefined();
+    });
+
+    it('does not trigger with none sampling', () => {
+      const report = { ...defaultReport(), testedPages: 1, samplingStrategy: 'none' as const };
+      const diags = evaluateDiagnostics(resultsMap(), report);
+      expect(diags.find((d) => d.id === 'single-page-sample')).toBeUndefined();
+    });
+
+    it('does not trigger when testedPages > 1', () => {
+      const report = { ...defaultReport(), testedPages: 5, samplingStrategy: 'random' as const };
+      const diags = evaluateDiagnostics(resultsMap(), report);
+      expect(diags.find((d) => d.id === 'single-page-sample')).toBeUndefined();
+    });
+
+    it('does not trigger when testedPages is undefined', () => {
+      const report = { ...defaultReport(), testedPages: undefined };
+      const diags = evaluateDiagnostics(resultsMap(), report);
+      expect(diags.find((d) => d.id === 'single-page-sample')).toBeUndefined();
+    });
+  });
+
+  describe('cross-origin-llms-txt', () => {
+    it('triggers when all links are cross-origin', () => {
+      const results = resultsMap(
+        r('llms-txt-links-resolve', 'warn', {
+          sameOrigin: { total: 0 },
+          crossOrigin: { total: 15, dominantOrigin: 'https://docs.example.com' },
+        }),
+      );
+      const diags = evaluateDiagnostics(results, defaultReport());
+      const diag = diags.find((d) => d.id === 'cross-origin-llms-txt');
+      expect(diag).toBeDefined();
+      expect(diag!.severity).toBe('warning');
+      expect(diag!.message).toContain('15 links');
+      expect(diag!.message).toContain('https://docs.example.com');
+    });
+
+    it('does not trigger when there are same-origin links', () => {
+      const results = resultsMap(
+        r('llms-txt-links-resolve', 'pass', {
+          sameOrigin: { total: 10 },
+          crossOrigin: { total: 5 },
+        }),
+      );
+      const diags = evaluateDiagnostics(results, defaultReport());
+      expect(diags.find((d) => d.id === 'cross-origin-llms-txt')).toBeUndefined();
+    });
+
+    it('does not trigger when check is skipped', () => {
+      const results = resultsMap(r('llms-txt-links-resolve', 'skip'));
+      const diags = evaluateDiagnostics(results, defaultReport());
+      expect(diags.find((d) => d.id === 'cross-origin-llms-txt')).toBeUndefined();
+    });
+
+    it('does not trigger when there are no cross-origin links', () => {
+      const results = resultsMap(
+        r('llms-txt-links-resolve', 'pass', {
+          sameOrigin: { total: 0 },
+          crossOrigin: { total: 0 },
+        }),
+      );
+      const diags = evaluateDiagnostics(results, defaultReport());
+      expect(diags.find((d) => d.id === 'cross-origin-llms-txt')).toBeUndefined();
+    });
+  });
+
+  describe('gzipped-sitemap-skipped', () => {
+    it('triggers when a check has a gzipped sitemap warning', () => {
+      const results = resultsMap(
+        r('page-size-html', 'pass', {
+          discoveryWarnings: [
+            'Skipped gzipped sitemap (not supported): https://example.com/sitemap.xml.gz',
+          ],
+        }),
+      );
+      const diags = evaluateDiagnostics(results, defaultReport());
+      const diag = diags.find((d) => d.id === 'gzipped-sitemap-skipped');
+      expect(diag).toBeDefined();
+      expect(diag!.severity).toBe('info');
+      expect(diag!.message).toContain('sitemap.xml.gz');
+    });
+
+    it('does not trigger without gzipped sitemap warnings', () => {
+      const results = resultsMap(
+        r('page-size-html', 'pass', {
+          discoveryWarnings: ['Some other warning'],
+        }),
+      );
+      const diags = evaluateDiagnostics(results, defaultReport());
+      expect(diags.find((d) => d.id === 'gzipped-sitemap-skipped')).toBeUndefined();
+    });
+
+    it('does not trigger with no discovery warnings', () => {
+      const results = resultsMap(r('page-size-html', 'pass'));
+      const diags = evaluateDiagnostics(results, defaultReport());
+      expect(diags.find((d) => d.id === 'gzipped-sitemap-skipped')).toBeUndefined();
+    });
+  });
+
+  describe('rate-limiting-severe', () => {
+    it('triggers when >20% of requests are rate-limited', () => {
+      const results = resultsMap(
+        r('llms-txt-links-resolve', 'warn', {
+          testedLinks: 50,
+          rateLimited: 15,
+        }),
+      );
+      const diags = evaluateDiagnostics(results, defaultReport());
+      const diag = diags.find((d) => d.id === 'rate-limiting-severe');
+      expect(diag).toBeDefined();
+      expect(diag!.severity).toBe('warning');
+      expect(diag!.message).toContain('30%');
+    });
+
+    it('does not trigger when rate limiting is below threshold', () => {
+      const results = resultsMap(
+        r('llms-txt-links-resolve', 'pass', {
+          testedLinks: 50,
+          rateLimited: 5,
+        }),
+      );
+      const diags = evaluateDiagnostics(results, defaultReport());
+      expect(diags.find((d) => d.id === 'rate-limiting-severe')).toBeUndefined();
+    });
+
+    it('aggregates rate limiting across multiple checks', () => {
+      const results = resultsMap(
+        r('llms-txt-links-resolve', 'pass', {
+          testedLinks: 50,
+          rateLimited: 5,
+        }),
+        r('markdown-url-support', 'warn', {
+          pageResults: Array.from({ length: 10 }, () => ({})),
+          rateLimited: 8,
+        }),
+      );
+      const diags = evaluateDiagnostics(results, defaultReport());
+      // 13/60 = 21.7% -> triggers
+      expect(diags.find((d) => d.id === 'rate-limiting-severe')).toBeDefined();
+    });
+
+    it('does not trigger when no checks have rate limiting data', () => {
+      const results = resultsMap(r('page-size-html', 'pass'));
+      const diags = evaluateDiagnostics(results, defaultReport());
+      expect(diags.find((d) => d.id === 'rate-limiting-severe')).toBeUndefined();
     });
   });
 });

--- a/test/unit/scoring/score.test.ts
+++ b/test/unit/scoring/score.test.ts
@@ -487,7 +487,7 @@ describe('computeScore', () => {
     it('does not mark checks as notApplicable when testedPages > 1', () => {
       const results: CheckResult[] = [makeResult('page-size-html', 'page-size', 'pass')];
       const score = computeScore(
-        makeReport(results, { testedPages: 5, samplingStrategy: 'random' }),
+        makeReport(results, { testedPages: 10, samplingStrategy: 'random' }),
       );
       expect(score.checkScores['page-size-html'].scoreDisplayMode).toBe('numeric');
     });
@@ -536,7 +536,7 @@ describe('computeScore', () => {
       );
       // Without N/A: both count, page-size-html fails -> less than 100
       const scoreNormal = computeScore(
-        makeReport(results, { testedPages: 5, samplingStrategy: 'random' }),
+        makeReport(results, { testedPages: 10, samplingStrategy: 'random' }),
       );
       expect(scoreNA.overall).toBe(100);
       expect(scoreNormal.overall).toBeLessThan(100);

--- a/test/unit/scoring/score.test.ts
+++ b/test/unit/scoring/score.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { computeScore, toGrade } from '../../../src/scoring/score.js';
-import type { CheckResult, ReportResult } from '../../../src/types.js';
+import type { CheckResult, ReportResult, SamplingStrategy } from '../../../src/types.js';
 
 function makeResult(
   id: string,
@@ -11,7 +11,10 @@ function makeResult(
   return { id, category, status, message: `${id}: ${status}`, details };
 }
 
-function makeReport(results: CheckResult[]): ReportResult {
+function makeReport(
+  results: CheckResult[],
+  overrides?: { testedPages?: number; samplingStrategy?: SamplingStrategy },
+): ReportResult {
   const summary = { total: results.length, pass: 0, warn: 0, fail: 0, skip: 0, error: 0 };
   for (const r of results) {
     summary[r.status]++;
@@ -22,6 +25,7 @@ function makeReport(results: CheckResult[]): ReportResult {
     specUrl: 'https://agentdocsspec.com/spec/',
     results,
     summary,
+    ...overrides,
   };
 }
 
@@ -450,6 +454,133 @@ describe('computeScore', () => {
       ];
       const score = computeScore(makeReport(results));
       expect(score.tagScores).toBeUndefined();
+    });
+  });
+
+  describe('single-page scoring (scoreDisplayMode)', () => {
+    it('marks page-level checks as notApplicable when testedPages=1 and discovery-based', () => {
+      const results: CheckResult[] = [
+        makeResult('llms-txt-exists', 'content-discoverability', 'pass'),
+        makeResult('page-size-html', 'page-size', 'pass'),
+        makeResult('rendering-strategy', 'page-size', 'pass', {
+          serverRendered: 1,
+          sparseContent: 0,
+          spaShells: 0,
+        }),
+      ];
+      const score = computeScore(
+        makeReport(results, { testedPages: 1, samplingStrategy: 'random' }),
+      );
+      expect(score.checkScores['llms-txt-exists'].scoreDisplayMode).toBe('numeric');
+      expect(score.checkScores['page-size-html'].scoreDisplayMode).toBe('notApplicable');
+      expect(score.checkScores['rendering-strategy'].scoreDisplayMode).toBe('notApplicable');
+    });
+
+    it('does not mark checks as notApplicable with curated sampling', () => {
+      const results: CheckResult[] = [makeResult('page-size-html', 'page-size', 'pass')];
+      const score = computeScore(
+        makeReport(results, { testedPages: 1, samplingStrategy: 'curated' }),
+      );
+      expect(score.checkScores['page-size-html'].scoreDisplayMode).toBe('numeric');
+    });
+
+    it('does not mark checks as notApplicable when testedPages > 1', () => {
+      const results: CheckResult[] = [makeResult('page-size-html', 'page-size', 'pass')];
+      const score = computeScore(
+        makeReport(results, { testedPages: 5, samplingStrategy: 'random' }),
+      );
+      expect(score.checkScores['page-size-html'].scoreDisplayMode).toBe('numeric');
+    });
+
+    it('nulls category scores when all checks in category are notApplicable', () => {
+      const results: CheckResult[] = [
+        makeResult('llms-txt-exists', 'content-discoverability', 'pass'),
+        makeResult('http-status-codes', 'url-stability', 'pass'),
+        makeResult('redirect-behavior', 'url-stability', 'pass'),
+      ];
+      const score = computeScore(
+        makeReport(results, { testedPages: 1, samplingStrategy: 'random' }),
+      );
+      // url-stability has only page-level checks -> null
+      expect(score.categoryScores['url-stability'].score).toBeNull();
+      expect(score.categoryScores['url-stability'].grade).toBeNull();
+      // content-discoverability has site-level check -> numeric
+      expect(score.categoryScores['content-discoverability'].score).toBe(100);
+    });
+
+    it('computes mixed category scores from numeric checks only', () => {
+      const results: CheckResult[] = [
+        makeResult('llms-txt-coverage', 'observability', 'pass'),
+        makeResult('cache-header-hygiene', 'observability', 'pass'),
+      ];
+      const score = computeScore(
+        makeReport(results, { testedPages: 1, samplingStrategy: 'random' }),
+      );
+      // observability: llms-txt-coverage is site-level (numeric), cache-header-hygiene is page-level (N/A)
+      // score computed from only llms-txt-coverage
+      expect(score.categoryScores['observability'].score).toBe(100);
+    });
+
+    it('excludes notApplicable checks from overall score', () => {
+      const results: CheckResult[] = [
+        makeResult('llms-txt-exists', 'content-discoverability', 'pass'),
+        makeResult('page-size-html', 'page-size', 'fail', {
+          passBucket: 0,
+          warnBucket: 0,
+          failBucket: 1,
+        }),
+      ];
+      // With N/A: only llms-txt-exists counts (pass) -> 100
+      const scoreNA = computeScore(
+        makeReport(results, { testedPages: 1, samplingStrategy: 'random' }),
+      );
+      // Without N/A: both count, page-size-html fails -> less than 100
+      const scoreNormal = computeScore(
+        makeReport(results, { testedPages: 5, samplingStrategy: 'random' }),
+      );
+      expect(scoreNA.overall).toBe(100);
+      expect(scoreNormal.overall).toBeLessThan(100);
+    });
+
+    it('fires single-page-sample diagnostic when N/A condition met', () => {
+      const results: CheckResult[] = [
+        makeResult('llms-txt-exists', 'content-discoverability', 'fail'),
+        makeResult('page-size-html', 'page-size', 'pass'),
+      ];
+      const score = computeScore(
+        makeReport(results, { testedPages: 1, samplingStrategy: 'random' }),
+      );
+      expect(score.diagnostics.find((d) => d.id === 'single-page-sample')).toBeDefined();
+    });
+
+    it('all checks get numeric scoreDisplayMode by default (no sampling info)', () => {
+      const results: CheckResult[] = [makeResult('page-size-html', 'page-size', 'pass')];
+      const score = computeScore(makeReport(results));
+      expect(score.checkScores['page-size-html'].scoreDisplayMode).toBe('numeric');
+    });
+
+    it('does not apply rendering-strategy cap when check is notApplicable', () => {
+      const results: CheckResult[] = [
+        makeResult('llms-txt-exists', 'content-discoverability', 'pass'),
+        makeResult('rendering-strategy', 'page-size', 'fail', {
+          serverRendered: 0,
+          sparseContent: 0,
+          spaShells: 1,
+        }),
+      ];
+      // With N/A: rendering-strategy is notApplicable, cap should NOT fire
+      const scoreNA = computeScore(
+        makeReport(results, { testedPages: 1, samplingStrategy: 'random' }),
+      );
+      expect(scoreNA.checkScores['rendering-strategy'].scoreDisplayMode).toBe('notApplicable');
+      expect(scoreNA.cap).toBeUndefined();
+
+      // Without N/A: same data, cap SHOULD fire
+      const scoreNormal = computeScore(
+        makeReport(results, { testedPages: 10, samplingStrategy: 'random' }),
+      );
+      expect(scoreNormal.cap).toBeDefined();
+      expect(scoreNormal.cap!.cap).toBe(39);
     });
   });
 });


### PR DESCRIPTION
## Summary

- When automatic page discovery finds only a few pages (`random`/`deterministic` sampling), page-level checks are marked `notApplicable` and excluded from the overall score. Category scores for all-N/A categories render as `–` instead of misleading numbers. Site-level checks (llms.txt, coverage, auth-alternative-access) still score normally. This does not apply to `--urls`, `--sampling curated`, or `--sampling none`, where the user intentionally chose what to test.
- Adds four new run-level diagnostics: `single-page-sample` (warns when only one page was discovered), `cross-origin-llms-txt` (all llms.txt links point to a different origin, suggests `--canonical-origin`), `gzipped-sitemap-skipped` (gzipped sitemap was skipped during discovery), `rate-limiting-severe` (>20% of requests got HTTP 429).
- Score caps from `rendering-strategy` and `auth-gate-detection` now skip checks marked `notApplicable`, so a single discovered SPA shell page can't cap the score at 39 while simultaneously being excluded from it.

## Breaking changes

- `CheckScore` has a new required field: `scoreDisplayMode` (`"numeric"` | `"notApplicable"`)
- `CategoryScore.score` and `.grade` can now be `null`
- `ReportResult` has new optional fields: `testedPages` and `samplingStrategy`
- `evaluateDiagnostics()` now requires a second argument (`ReportResult`)
- `llms-txt-links-resolve` details `crossOrigin` object has a new `dominantOrigin` field
- `rendering-strategy`/`auth-gate-detection` caps no longer apply when the check is `notApplicable`

## Test plan

- [x] `npm test` — 943 tests pass (32 new: 10 score, 18 diagnostics, 4 scorecard formatter)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint .` — clean
- [x] End-to-end scorecard test: report with `testedPages: 1, samplingStrategy: 'random'` renders N/A categories as dash and fires `single-page-sample` diagnostic
- [x] Cap edge case: `rendering-strategy` fail with `testedPages: 1` does NOT cap the score
- [x] Manual smoke test: `npx afdocs check <site-with-no-llms-txt> --format scorecard` shows N/A categories and single-page-sample diagnostic

Closes #23