### PR TITLE
Handle intentional audience segmentation in 'markdown-content-parity'

### DIFF
--- a/docs/checks/observability.md
+++ b/docs/checks/observability.md
@@ -36,8 +36,8 @@ The check supports three use cases through configurable thresholds and exclusion
 
 **CLI flags:**
 
-- `--coverage-pass-threshold <n>` — Pass threshold (0-100, default 95)
-- `--coverage-warn-threshold <n>` — Warn threshold (0-100, default 80)
+- `--coverage-pass-threshold <n>` — Minimum coverage % to pass (0-100, default 95; higher = stricter)
+- `--coverage-warn-threshold <n>` — Minimum coverage % to avoid failure (0-100, default 80; higher = stricter)
 - `--coverage-exclusions <patterns>` — Comma-separated glob patterns to exclude from the sitemap before calculating coverage (e.g. `"/docs/reference/**,/docs/changelog/**"`)
 
 These can also be set in `agent-docs.config.yml` under `options`:
@@ -108,21 +108,66 @@ Whether markdown and HTML versions of pages contain the same content.
 
 When markdown is generated separately from HTML (not served directly from source), the two can drift. A site updates its HTML but forgets to regenerate the markdown, leaving agents with outdated instructions or code examples. Or a build pipeline that generates markdown misses some of the content. This is particularly insidious because agents receiving the markdown version have no signal that content is missing or outdated, and humans typically don't look at both page formats to spot discrepancies.
 
+However, content divergence is sometimes intentional. Some sites serve different content to different audiences: agent-optimized markdown alongside human-optimized HTML. In those cases, divergence is a feature, not a bug. The check supports this through audience-segmentation markers and configurable thresholds.
+
 ### Results
 
-Based on the percentage of HTML content segments missing from the markdown version, after normalization:
+Based on the percentage of HTML content segments missing from the markdown version, after normalization. Thresholds are configurable.
 
-| Result | Condition                                                                                     |
-| ------ | --------------------------------------------------------------------------------------------- |
-| Pass   | Under 5% of content segments missing                                                          |
-| Warn   | 5-20% missing (minor differences like formatting or navigation elements)                      |
-| Fail   | 20% or more missing (substantive differences like missing sections or outdated code examples) |
+| Result | Condition                                                     |
+| ------ | ------------------------------------------------------------- |
+| Pass   | Under pass threshold (default 5%) of content segments missing |
+| Warn   | Between pass and warn thresholds (default 5-20% missing)      |
+| Fail   | Above warn threshold (default 20% or more missing)            |
+
+### Audience segmentation
+
+Some documentation platforms let site owners serve different content to different audiences. For example, a page might show UI-oriented instructions ("Click the gear icon...") in HTML but API-oriented instructions ("Call `POST /v1/settings`...") in markdown. The check accounts for this in two ways:
+
+**`data-markdown-ignore` attribute.** Add this attribute to HTML elements that contain human-only content (content intentionally excluded from markdown). The check strips these elements before comparing, so they don't count as "missing."
+
+```html
+<div data-markdown-ignore>
+  <p>Click the gear icon in the top-right corner to open settings.</p>
+</div>
+```
+
+This is the recommended convention for platforms that render HTML server-side. If your documentation platform controls the HTML output, adding `data-markdown-ignore` to human-only wrapper elements lets the parity check handle segmentation automatically with no user configuration.
+
+**Configurable thresholds.** For platforms that process segmentation tags server-side (like Fern and Mintlify, where the tags never appear in the rendered HTML), adjust thresholds to match your expected divergence level.
+
+### Configuring parity
+
+The check supports three use cases, matching the same mirrored-to-curated spectrum as `llms-txt-coverage`:
+
+- **Mirrored** (default): Markdown should match HTML. Default thresholds (5/20) apply.
+- **Segmented**: The site uses `data-markdown-ignore` to mark human-only HTML content. The check strips tagged content before comparing; remaining shared content is held to default thresholds.
+- **Curated**: The site intentionally serves different content with no tag-level signal. Set thresholds to 0 (`--parity-pass-threshold 0 --parity-warn-threshold 0`) to make the check informational. It still reports the missing percentage, but does not warn or fail.
+
+**CLI flags:**
+
+- `--parity-pass-threshold <n>` — Maximum missing % to pass (0-100, default 5; lower = stricter). Set to 0 to disable warnings.
+- `--parity-warn-threshold <n>` — Maximum missing % to avoid failure (0-100, default 20; lower = stricter). Set to 0 to disable failures.
+- `--parity-exclusions <selectors>` — Comma-separated CSS selectors to strip from HTML before comparison, for platform-specific conventions beyond `data-markdown-ignore` (e.g. `".human-only,[data-audience='humans']"`)
+
+These can also be set in `agent-docs.config.yml` under `options`:
+
+```yaml
+options:
+  parityPassThreshold: 10
+  parityWarnThreshold: 30
+  parityExclusions:
+    - .human-only-content
+    - '[data-audience="humans"]' # quote selectors starting with [ (YAML treats unquoted [] as arrays)
+```
+
+Note: `data-markdown-ignore` is built in and does not need to be listed in `parityExclusions`. The exclusions option is only for additional platform-specific conventions.
 
 ### How to fix
 
-**If this check warns**, review the differences for formatting variations. Minor parity issues (navigation elements present in one format but not the other) may be acceptable.
+**If this check warns**, review the differences. If they reflect intentional audience segmentation, either add `data-markdown-ignore` to the human-only HTML elements or adjust thresholds. If they reflect formatting variations, minor parity issues (navigation elements present in one format but not the other) may be acceptable.
 
-**If this check fails**, your markdown and HTML versions have substantive content differences. Regenerate markdown from source, or fix the build pipeline to keep both formats in sync. The most reliable approach is serving markdown directly from the same source files used to generate HTML, rather than maintaining two separate outputs.
+**If this check fails**, your markdown and HTML versions have substantive content differences. If unintentional, regenerate markdown from source or fix the build pipeline. The most reliable approach is serving markdown directly from the same source files used to generate HTML. If intentional (audience segmentation), add `data-markdown-ignore` to human-only HTML elements, use `--parity-exclusions` for custom conventions, or set thresholds to 0 for informational mode.
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -202,8 +202,8 @@ The defaults (50K pass, 100K fail) reflect observed agent truncation limits. You
 
 | Flag                               | Default | Description                                                   |
 | ---------------------------------- | ------- | ------------------------------------------------------------- |
-| `--coverage-pass-threshold <n>`    | `95`    | `llms-txt-coverage` pass threshold (percentage, 0-100)        |
-| `--coverage-warn-threshold <n>`    | `80`    | `llms-txt-coverage` warn threshold (percentage, 0-100)        |
+| `--coverage-pass-threshold <n>`    | `95`    | Minimum coverage % to pass (higher = stricter)                |
+| `--coverage-warn-threshold <n>`    | `80`    | Minimum coverage % to avoid failure (higher = stricter)       |
 | `--coverage-exclusions <patterns>` |         | Comma-separated glob patterns to exclude from the denominator |
 
 These control the `llms-txt-coverage` check, which compares `llms.txt` page URLs against the sitemap. Set both thresholds to `0` to make the check informational: it still reports coverage percentage and missing pages, but doesn't warn or fail.
@@ -212,6 +212,25 @@ Use exclusion patterns with glob syntax (`**` matches across path segments, `*` 
 
 ```bash
 afdocs check https://example.com --coverage-exclusions "/docs/reference/**,/docs/changelog/**"
+```
+
+### Parity thresholds
+
+| Flag                              | Default | Description                                                               |
+| --------------------------------- | ------- | ------------------------------------------------------------------------- |
+| `--parity-pass-threshold <n>`     | `5`     | Maximum missing % to pass (lower = stricter)                              |
+| `--parity-warn-threshold <n>`     | `20`    | Maximum missing % to avoid failure (lower = stricter)                     |
+| `--parity-exclusions <selectors>` |         | Comma-separated CSS selectors to strip from HTML before parity comparison |
+
+These control the `markdown-content-parity` check, which compares HTML content against markdown to detect drift. Set both thresholds to `0` to make the check informational: it still reports the missing percentage, but doesn't warn or fail. This is useful for sites that intentionally serve different content to different audiences.
+
+The check also has built-in support for the `data-markdown-ignore` HTML attribute. Elements with this attribute are stripped from the HTML before comparison, so human-only content doesn't count as "missing" from markdown.
+
+Use `--parity-exclusions` for platform-specific conventions beyond `data-markdown-ignore`:
+
+```bash
+# Strip elements with a custom class or data attribute
+afdocs check https://example.com --parity-exclusions ".human-only-content,[data-audience='humans']"
 ```
 
 ## Exit codes

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -43,6 +43,12 @@ options:
   #   - /docs/reference/**
   #   - /docs/changelog/**
   #   - "**/release-notes/**"  # quote patterns starting with *
+  # Parity check: thresholds and exclusions
+  # parityPassThreshold: 5
+  # parityWarnThreshold: 20
+  # parityExclusions:
+  #   - .human-only-content
+  #   - '[data-audience="humans"]'  # quote selectors starting with [ (YAML treats unquoted [] as arrays)
 
 # Optional: test specific pages instead of discovering via llms.txt/sitemap
 # pages:
@@ -91,9 +97,12 @@ Override default runner options. All fields are optional:
 | `llmsTxtUrl`            |             | Explicit llms.txt URL to use as canonical (overrides the discovery heuristic; see CLI docs)              |
 | `thresholds.pass`       | `50000`     | Page size pass threshold in characters                                                                   |
 | `thresholds.fail`       | `100000`    | Page size fail threshold in characters                                                                   |
-| `coveragePassThreshold` | `95`        | `llms-txt-coverage` pass threshold (percentage, 0-100)                                                   |
-| `coverageWarnThreshold` | `80`        | `llms-txt-coverage` warn threshold (percentage, 0-100)                                                   |
+| `coveragePassThreshold` | `95`        | `llms-txt-coverage` pass threshold: minimum coverage % to pass (higher = stricter)                       |
+| `coverageWarnThreshold` | `80`        | `llms-txt-coverage` warn threshold: minimum coverage % to avoid failure (higher = stricter)              |
 | `coverageExclusions`    |             | Glob patterns to exclude from the sitemap before calculating coverage (quote patterns starting with `*`) |
+| `parityPassThreshold`   | `5`         | `markdown-content-parity` pass threshold: maximum missing % to pass (lower = stricter)                   |
+| `parityWarnThreshold`   | `20`        | `markdown-content-parity` warn threshold: maximum missing % to avoid failure (lower = stricter)          |
+| `parityExclusions`      |             | CSS selectors to strip from HTML before parity comparison                                                |
 
 ### `pages` (optional)
 

--- a/src/checks/observability/markdown-content-parity.ts
+++ b/src/checks/observability/markdown-content-parity.ts
@@ -2,11 +2,8 @@ import { parse } from 'node-html-parser';
 import { registerCheck } from '../registry.js';
 import { fetchPage } from '../../helpers/fetch-page.js';
 import { toHtmlUrl } from '../../helpers/to-md-urls.js';
+import { DEFAULT_PARITY_PASS_THRESHOLD, DEFAULT_PARITY_WARN_THRESHOLD } from '../../constants.js';
 import type { CheckContext, CheckResult, CheckStatus } from '../../types.js';
-
-/** Thresholds for the percentage of HTML segments not found in markdown. */
-const WARN_THRESHOLD = 5;
-const FAIL_THRESHOLD = 20;
 
 /** Minimum character length for a text segment to be considered meaningful. */
 const MIN_SEGMENT_LENGTH = 20;
@@ -268,7 +265,12 @@ const CONTENT_SELECTORS = [
   '.prose',
 ];
 
-function extractHtmlText(html: string): string {
+interface HtmlExtractionResult {
+  text: string;
+  segmentationStripped: number;
+}
+
+function extractHtmlText(html: string, parityExclusions?: string[]): HtmlExtractionResult {
   const root = parse(html);
 
   // Prefer the tightest content container available.
@@ -298,7 +300,32 @@ function extractHtmlText(html: string): string {
   }
 
   if (!content) content = root.querySelector('body');
-  if (!content) return root.text;
+  if (!content) return { text: root.text, segmentationStripped: 0 };
+
+  // Strip audience-segmentation elements before comparison.
+  // data-markdown-ignore marks content intended only for human readers;
+  // it is expected to be absent from the markdown version.
+  let segmentationStripped = 0;
+  for (const el of content.querySelectorAll('[data-markdown-ignore]')) {
+    el.remove();
+    segmentationStripped++;
+  }
+
+  // Strip user-provided CSS selectors (additional platform conventions)
+  if (parityExclusions?.length) {
+    for (const selector of parityExclusions) {
+      try {
+        for (const el of content.querySelectorAll(selector)) {
+          el.remove();
+        }
+      } catch {
+        throw new Error(
+          `Invalid CSS selector in parityExclusions: "${selector}". ` +
+            'If the selector contains [ or ], wrap it in quotes in your YAML config.',
+        );
+      }
+    }
+  }
 
   // Remove non-content elements by tag
   for (const tag of STRIP_TAGS) {
@@ -345,24 +372,18 @@ function extractHtmlText(html: string): string {
   // Expressive Code / Shiki use <div class="ec-line"> inside <pre>),
   // then strip HTML tags while preserving angle-bracket placeholders
   // like <YOUR_API_KEY> or <clusterName> (decoded from &lt;...&gt; entities).
-  return content.text
+  const text = content.text
     .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
     .replace(/<!--[\s\S]*?-->/g, '')
     .replace(/<div[\s>]/gi, '\n<div ')
     .replace(/<\/[^>\s]+>/g, '')
     .replace(/<([a-zA-Z][a-zA-Z0-9-]*)([^>]*)>/g, (_match, tag, rest) => {
       const lower = tag.toLowerCase();
-      // Tags already removed at the DOM level can't appear as real elements
-      // in .text output — they must be entity-decoded text (e.g., prose
-      // discussing <nav> elements). Keep the tag name as text content.
       if (DOM_STRIPPED_TAGS.has(lower)) return tag;
-      // Other known tags (span, div, code, etc.) appear in <pre> block
-      // text output from syntax highlighting — strip them entirely.
       if (HTML_TAG_NAMES.has(lower)) return '';
-      // Unknown "tags" are angle-bracket placeholders like <YOUR_API_KEY>
-      // decoded from entities — keep the full content.
       return tag + rest;
     });
+  return { text, segmentationStripped };
 }
 
 /**
@@ -512,6 +533,8 @@ function toSegments(text: string): string[] {
 function computeParity(
   htmlText: string,
   markdownText: string,
+  warnThreshold: number,
+  failThreshold: number,
 ): Omit<PageParityResult, 'url' | 'markdownSource' | 'error'> {
   // Deduplicate segments so repeated chrome (breadcrumbs, nav titles) or
   // repeated content is only counted once when checking for presence.
@@ -565,13 +588,18 @@ function computeParity(
   const missingPercent =
     htmlSegments.length > 0 ? Math.round((missingCount / htmlSegments.length) * 100) : 0;
 
+  // A threshold of 0 means "disabled" (informational mode per spec).
+  // This naturally falls out: `0 > 0` is false, so the guard prevents
+  // the threshold from firing, and the check passes.
+  const shouldFail = failThreshold > 0 && missingPercent >= failThreshold;
+  const shouldWarn = warnThreshold > 0 && missingPercent >= warnThreshold;
   let status: CheckStatus;
-  if (missingPercent < WARN_THRESHOLD) {
-    status = 'pass';
-  } else if (missingPercent < FAIL_THRESHOLD) {
+  if (shouldFail) {
+    status = 'fail';
+  } else if (shouldWarn) {
     status = 'warn';
   } else {
-    status = 'fail';
+    status = 'pass';
   }
 
   return {
@@ -619,8 +647,25 @@ async function check(ctx: CheckContext): Promise<CheckResult> {
     };
   }
 
+  const warnThreshold = ctx.options.parityPassThreshold ?? DEFAULT_PARITY_PASS_THRESHOLD;
+  const failThreshold = ctx.options.parityWarnThreshold ?? DEFAULT_PARITY_WARN_THRESHOLD;
+  const parityExclusions = ctx.options.parityExclusions;
+
+  if (warnThreshold > failThreshold && failThreshold > 0) {
+    return {
+      id,
+      category,
+      status: 'error',
+      message:
+        `parityPassThreshold (${warnThreshold}) is greater than ` +
+        `parityWarnThreshold (${failThreshold}). The pass threshold must be ` +
+        'less than or equal to the warn threshold.',
+    };
+  }
+
   const results: PageParityResult[] = [];
   const concurrency = ctx.options.maxConcurrency;
+  let totalSegmentationStripped = 0;
 
   for (let i = 0; i < pagesToCompare.length; i += concurrency) {
     const batch = pagesToCompare.slice(i, i + concurrency);
@@ -658,8 +703,12 @@ async function check(ctx: CheckContext): Promise<CheckResult> {
             };
           }
 
-          const htmlText = extractHtmlText(page.body);
-          const parity = computeParity(htmlText, markdownContent);
+          const { text: htmlText, segmentationStripped } = extractHtmlText(
+            page.body,
+            parityExclusions,
+          );
+          totalSegmentationStripped += segmentationStripped;
+          const parity = computeParity(htmlText, markdownContent, warnThreshold, failThreshold);
 
           return { url, markdownSource, ...parity };
         } catch (err) {
@@ -727,6 +776,15 @@ async function check(ctx: CheckContext): Promise<CheckResult> {
       failBucket,
       fetchErrors,
       avgMissingPercent,
+      ...(totalSegmentationStripped > 0 && {
+        segmentationElementsStripped: totalSegmentationStripped,
+      }),
+      ...(ctx.options.parityPassThreshold != null && {
+        parityPassThreshold: warnThreshold,
+      }),
+      ...(ctx.options.parityWarnThreshold != null && {
+        parityWarnThreshold: failThreshold,
+      }),
       pageResults: results,
     },
   };

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -38,11 +38,29 @@ export function registerCheckCommand(program: Command): void {
     .option('-v, --verbose', 'Show per-page details for checks with issues')
     .option('--fixes', 'Show fix suggestions for warn/fail checks')
     .option('--score', 'Include scoring data in JSON output')
-    .option('--coverage-pass-threshold <n>', 'llms-txt-coverage pass threshold (0-100, default 95)')
-    .option('--coverage-warn-threshold <n>', 'llms-txt-coverage warn threshold (0-100, default 80)')
+    .option(
+      '--coverage-pass-threshold <n>',
+      'Minimum coverage % to pass (0-100, default 95; higher = stricter)',
+    )
+    .option(
+      '--coverage-warn-threshold <n>',
+      'Minimum coverage % to avoid failure (0-100, default 80; higher = stricter)',
+    )
     .option(
       '--coverage-exclusions <patterns>',
       'Comma-separated glob patterns to exclude from coverage denominator',
+    )
+    .option(
+      '--parity-pass-threshold <n>',
+      'Maximum missing % to pass (0-100, default 5; lower = stricter)',
+    )
+    .option(
+      '--parity-warn-threshold <n>',
+      'Maximum missing % to avoid failure (0-100, default 20; lower = stricter)',
+    )
+    .option(
+      '--parity-exclusions <selectors>',
+      'Comma-separated CSS selectors to strip from HTML before parity comparison',
     )
     .option(
       '--canonical-origin <url>',
@@ -244,6 +262,23 @@ export function registerCheckCommand(program: Command): void {
               .filter(Boolean)
           : (config?.options?.coverageExclusions ?? undefined);
 
+      const parityPassThreshold =
+        opts.parityPassThreshold != null
+          ? parseInt(String(opts.parityPassThreshold), 10)
+          : (config?.options?.parityPassThreshold ?? undefined);
+      const parityWarnThreshold =
+        opts.parityWarnThreshold != null
+          ? parseInt(String(opts.parityWarnThreshold), 10)
+          : (config?.options?.parityWarnThreshold ?? undefined);
+
+      const parityExclusions =
+        opts.parityExclusions != null
+          ? (opts.parityExclusions as string)
+              .split(',')
+              .map((s) => s.trim())
+              .filter(Boolean)
+          : (config?.options?.parityExclusions ?? undefined);
+
       const report = await runChecks(url, {
         checkIds,
         skipCheckIds,
@@ -263,6 +298,9 @@ export function registerCheckCommand(program: Command): void {
         ...(coveragePassThreshold != null && { coveragePassThreshold }),
         ...(coverageWarnThreshold != null && { coverageWarnThreshold }),
         ...(coverageExclusions && { coverageExclusions }),
+        ...(parityPassThreshold != null && { parityPassThreshold }),
+        ...(parityWarnThreshold != null && { parityWarnThreshold }),
+        ...(parityExclusions && { parityExclusions }),
       });
 
       let output: string;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,6 +40,12 @@ export const DEFAULT_COVERAGE_PASS_THRESHOLD = 95;
 /** Default llms-txt-coverage warn threshold (percentage). */
 export const DEFAULT_COVERAGE_WARN_THRESHOLD = 80;
 
+/** Default markdown-content-parity pass threshold (percentage of missing segments). */
+export const DEFAULT_PARITY_PASS_THRESHOLD = 5;
+
+/** Default markdown-content-parity warn threshold (percentage of missing segments). */
+export const DEFAULT_PARITY_WARN_THRESHOLD = 20;
+
 /** Minimum discovered pages before page-level scores are considered meaningful. */
 export const MIN_PAGES_FOR_SCORING = 5;
 

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -40,6 +40,34 @@ export function validatePages(pages: unknown[], source: string): void {
 }
 
 /**
+ * Validate that a config field is a flat array of strings.
+ * Catches the common YAML mistake of unquoted values containing special
+ * characters (e.g., `[data-foo]` parsed as a nested array instead of a string).
+ */
+function validateStringArray(value: unknown, field: string, source: string): void {
+  if (!Array.isArray(value)) {
+    throw new Error(`${source}: "${field}" must be an array of strings`);
+  }
+  for (let i = 0; i < value.length; i++) {
+    if (typeof value[i] !== 'string') {
+      throw new Error(
+        `${source}: ${field}[${i}] must be a string, got ${typeof value[i]}. ` +
+          'If the value contains [ or *, wrap it in quotes.',
+      );
+    }
+  }
+}
+
+function validateOptions(options: Record<string, unknown>, source: string): void {
+  if (options.coverageExclusions != null) {
+    validateStringArray(options.coverageExclusions, 'options.coverageExclusions', source);
+  }
+  if (options.parityExclusions != null) {
+    validateStringArray(options.parityExclusions, 'options.parityExclusions', source);
+  }
+}
+
+/**
  * Search for an agent-docs config file starting from `dir` and walking up
  * to the filesystem root (like eslint, prettier, etc.).
  * If `dir` is omitted, starts from `process.cwd()`.
@@ -59,6 +87,9 @@ export async function loadConfig(dir?: string): Promise<AgentDocsConfig> {
         if (parsed.pages) {
           assertPagesArray(parsed.pages, filepath);
           validatePages(parsed.pages, filepath);
+        }
+        if (parsed.options) {
+          validateOptions(parsed.options as Record<string, unknown>, filepath);
         }
         return parsed;
       } catch (err) {
@@ -96,6 +127,9 @@ export async function findConfig(
       assertPagesArray(parsed.pages, filepath);
       validatePages(parsed.pages, filepath);
     }
+    if (parsed.options) {
+      validateOptions(parsed.options as Record<string, unknown>, filepath);
+    }
     return parsed;
   }
 
@@ -109,6 +143,9 @@ export async function findConfig(
         if (parsed.pages) {
           assertPagesArray(parsed.pages, filepath);
           validatePages(parsed.pages, filepath);
+        }
+        if (parsed.options) {
+          validateOptions(parsed.options as Record<string, unknown>, filepath);
         }
         return parsed;
       } catch (err) {

--- a/src/scoring/resolutions.ts
+++ b/src/scoring/resolutions.ts
@@ -314,7 +314,9 @@ const RESOLUTION_TEMPLATES: Record<string, ResolutionTemplate> = {
       const warnCount = (d.warnBucket as number) ?? 0;
       return (
         `${warnCount} pages have minor content differences between their ` +
-        'markdown and HTML versions. Review for formatting variations.'
+        'markdown and HTML versions. If this is intentional audience ' +
+        'segmentation, adjust --parity-pass-threshold and ' +
+        '--parity-warn-threshold (set both to 0 for informational mode).'
       );
     },
     fail: (d) => {
@@ -323,9 +325,11 @@ const RESOLUTION_TEMPLATES: Record<string, ResolutionTemplate> = {
       return (
         `${failCount} pages have substantive content differences between ` +
         `markdown and HTML (avg ${Math.round(avgMissing)}% missing). ` +
-        'Agents receiving the markdown version are getting outdated or ' +
-        'incomplete content. Regenerate markdown from source or fix the ' +
-        'build pipeline.'
+        'If unintentional, agents are getting outdated content; ' +
+        'regenerate markdown from source or fix the build pipeline. ' +
+        'If intentional (audience segmentation), add ' +
+        'data-markdown-ignore to human-only HTML elements, or adjust ' +
+        'thresholds with --parity-pass-threshold/--parity-warn-threshold.'
       );
     },
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,12 @@ export interface CheckOptions {
   coverageWarnThreshold?: number;
   /** Glob patterns to exclude from the sitemap before calculating coverage. */
   coverageExclusions?: string[];
+  /** Pass threshold for markdown-content-parity (0–100). Default 5. */
+  parityPassThreshold?: number;
+  /** Warn threshold for markdown-content-parity (0–100). Default 20. */
+  parityWarnThreshold?: number;
+  /** CSS selectors to strip from HTML before parity comparison (e.g. '[data-markdown-ignore]'). */
+  parityExclusions?: string[];
   /**
    * Explicit URL to use as the canonical llms.txt for downstream sampling and
    * analysis. When set, the standard candidate-discovery heuristic is bypassed

--- a/test/unit/checks/markdown-content-parity.test.ts
+++ b/test/unit/checks/markdown-content-parity.test.ts
@@ -18,8 +18,9 @@ describe('markdown-content-parity', () => {
   function makeCtx(
     pages: Array<{ url: string; markdown: string; htmlBody: string }>,
     host: string,
+    options?: Record<string, unknown>,
   ) {
-    const ctx = createContext(`http://${host}`, { requestDelay: 0 });
+    const ctx = createContext(`http://${host}`, { requestDelay: 0, ...options });
 
     // Simulate upstream markdown-url-support having run
     ctx.previousResults.set('markdown-url-support', {
@@ -1839,5 +1840,277 @@ Use a linter to automatically verify code fence syntax across all your documents
     expect(result.status).toBe('pass');
     const pageResults = result.details?.pageResults as Array<{ missingSegments: number }>;
     expect(pageResults[0].missingSegments).toBe(0);
+  });
+
+  // --- Audience segmentation tests ---
+
+  it('strips data-markdown-ignore elements from HTML before comparison', async () => {
+    // Content inside data-markdown-ignore is intended only for human readers;
+    // it is expected to be absent from the markdown version.
+    const html = `<html><body><main>
+      <h1>Getting Started</h1>
+      <p>Install the SDK with npm to add it to your project dependencies list.</p>
+      <div data-markdown-ignore>
+        <p>Click the gear icon in the top-right corner to open the settings panel.</p>
+        <p>Navigate to the API section and click Generate New Key to create credentials.</p>
+      </div>
+      <p>Then import the client module and configure it with your API credentials here.</p>
+      <p>Run the following commands to get started with the installation process now.</p>
+      <p>After installation import the client and call the initialize method first please.</p>
+      <p>The client will automatically detect your configuration from environment variables.</p>
+      <p>You can override any configuration option by passing it to the constructor directly.</p>
+      <p>Make sure your API key is set before attempting to make any requests to the server.</p>
+      <p>The library validates all configuration options and throws helpful error messages.</p>
+      <p>Connection pooling is handled automatically for optimal performance and throughput.</p>
+      <p>TLS certificates are verified by default to ensure secure communication channels.</p>
+    </main></body></html>`;
+
+    const markdown = `# Getting Started
+
+Install the SDK with npm to add it to your project dependencies list.
+
+Then import the client module and configure it with your API credentials here.
+
+Run the following commands to get started with the installation process now.
+
+After installation import the client and call the initialize method first please.
+
+The client will automatically detect your configuration from environment variables.
+
+You can override any configuration option by passing it to the constructor directly.
+
+Make sure your API key is set before attempting to make any requests to the server.
+
+The library validates all configuration options and throws helpful error messages.
+
+Connection pooling is handled automatically for optimal performance and throughput.
+
+TLS certificates are verified by default to ensure secure communication channels.`;
+
+    const url = 'http://mcp-segmentation.local/docs/start';
+
+    server.use(
+      http.get(
+        url,
+        () =>
+          new HttpResponse(html, {
+            status: 200,
+            headers: { 'Content-Type': 'text/html' },
+          }),
+      ),
+    );
+
+    const ctx = makeCtx([{ url, markdown, htmlBody: html }], 'mcp-segmentation.local');
+    const result = await check.run(ctx);
+    expect(result.status).toBe('pass');
+    const pageResults = result.details?.pageResults as Array<{ missingSegments: number }>;
+    expect(pageResults[0].missingSegments).toBe(0);
+    expect(result.details?.segmentationElementsStripped).toBe(1);
+  });
+
+  it('uses configurable thresholds (0/0 = informational mode)', async () => {
+    // Setting both thresholds to 0 means the check always passes,
+    // making it informational for sites with intentional content divergence.
+    const html = `<html><body>
+      <h1>Installation Guide</h1>
+      <p>You need Node.js 18 or later installed on your system before proceeding.</p>
+      <p>Create a configuration file with your API credentials and region settings.</p>
+      <p>Import and initialize the client using the configuration you just created.</p>
+      <p>Run the health check to verify everything is working correctly in your environment.</p>
+      <p>Common issues include connection timeouts and authentication failures with expired keys.</p>
+      <p>Check your network connectivity if you experience connection timeout errors repeatedly.</p>
+      <p>Verify your API key has not expired if you see authentication failure messages.</p>
+      <p>Make sure the target host is accessible and responding to network requests properly.</p>
+      <p>Review the troubleshooting section for additional debugging information and tips.</p>
+      <p>Contact support if you continue to experience issues after following these steps.</p>
+      <p>The installation process should take approximately five minutes from start to finish.</p>
+    </body></html>`;
+
+    const markdown = `# Changelog
+
+## v2.0.0
+
+Breaking changes in this release that affect all existing integrations.
+
+## v1.5.0
+
+Added new features for managing team resources and permissions.`;
+
+    const url = 'http://mcp-informational.local/docs/install';
+
+    server.use(
+      http.get(
+        url,
+        () =>
+          new HttpResponse(html, {
+            status: 200,
+            headers: { 'Content-Type': 'text/html' },
+          }),
+      ),
+    );
+
+    const ctx = makeCtx([{ url, markdown, htmlBody: html }], 'mcp-informational.local', {
+      parityPassThreshold: 0,
+      parityWarnThreshold: 0,
+    });
+    const result = await check.run(ctx);
+    // With thresholds at 0, even massive differences pass
+    expect(result.status).toBe('pass');
+    const pageResults = result.details?.pageResults as Array<{ missingPercent: number }>;
+    // The missing percentage is still reported even though the check passes
+    expect(pageResults[0].missingPercent).toBeGreaterThan(0);
+  });
+
+  it('applies custom parityExclusions CSS selectors', async () => {
+    // Site uses a custom attribute for audience segmentation that isn't
+    // data-markdown-ignore. The user provides it via parityExclusions.
+    const html = `<html><body><main>
+      <h1>API Reference</h1>
+      <p>The API supports the following operations for managing resources securely.</p>
+      <section class="human-only-ui-steps">
+        <p>Open the dashboard and navigate to the API Keys section in the sidebar.</p>
+        <p>Click the Create button to generate a new API key for your application.</p>
+      </section>
+      <p>Use bearer tokens for authentication with the API endpoints on every request.</p>
+      <p>Include your API key in the Authorization header of every request you send.</p>
+      <p>Requests are limited to one hundred per minute per API key by default now.</p>
+      <p>Error responses include a JSON body with a code field and a message for details.</p>
+      <p>Use cursor-based pagination with the after parameter in your requests to pages.</p>
+      <p>Each page returns up to fifty items by default unless configured otherwise here.</p>
+      <p>The SDK supports automatic retries with exponential backoff for transient failures.</p>
+      <p>Configure the maximum number of retries using the maxRetries constructor option.</p>
+      <p>All requests are authenticated automatically using the configured API credentials.</p>
+    </main></body></html>`;
+
+    const markdown = `# API Reference
+
+The API supports the following operations for managing resources securely.
+
+Use bearer tokens for authentication with the API endpoints on every request.
+
+Include your API key in the Authorization header of every request you send.
+
+Requests are limited to one hundred per minute per API key by default now.
+
+Error responses include a JSON body with a code field and a message for details.
+
+Use cursor-based pagination with the after parameter in your requests to pages.
+
+Each page returns up to fifty items by default unless configured otherwise here.
+
+The SDK supports automatic retries with exponential backoff for transient failures.
+
+Configure the maximum number of retries using the maxRetries constructor option.
+
+All requests are authenticated automatically using the configured API credentials.`;
+
+    const url = 'http://mcp-custom-excl.local/docs/api';
+
+    server.use(
+      http.get(
+        url,
+        () =>
+          new HttpResponse(html, {
+            status: 200,
+            headers: { 'Content-Type': 'text/html' },
+          }),
+      ),
+    );
+
+    const ctx = makeCtx([{ url, markdown, htmlBody: html }], 'mcp-custom-excl.local', {
+      parityExclusions: ['.human-only-ui-steps'],
+    });
+    const result = await check.run(ctx);
+    expect(result.status).toBe('pass');
+    const pageResults = result.details?.pageResults as Array<{ missingSegments: number }>;
+    expect(pageResults[0].missingSegments).toBe(0);
+  });
+
+  it('reports custom thresholds in details when non-default', async () => {
+    const html =
+      '<html><body><h1>Page</h1><p>Content that matches between HTML and markdown versions exactly.</p></body></html>';
+    const markdown = '# Page\n\nContent that matches between HTML and markdown versions exactly.';
+    const url = 'http://mcp-threshold-report.local/docs/page';
+
+    server.use(
+      http.get(
+        url,
+        () =>
+          new HttpResponse(html, {
+            status: 200,
+            headers: { 'Content-Type': 'text/html' },
+          }),
+      ),
+    );
+
+    const ctx = makeCtx([{ url, markdown, htmlBody: html }], 'mcp-threshold-report.local', {
+      parityPassThreshold: 10,
+      parityWarnThreshold: 30,
+    });
+    const result = await check.run(ctx);
+    expect(result.details?.parityPassThreshold).toBe(10);
+    expect(result.details?.parityWarnThreshold).toBe(30);
+  });
+
+  it('returns error when parityPassThreshold exceeds parityWarnThreshold', async () => {
+    const html =
+      '<html><body><h1>Page</h1><p>Content that matches between HTML and markdown versions exactly.</p></body></html>';
+    const markdown = '# Page\n\nContent that matches between HTML and markdown versions exactly.';
+    const url = 'http://mcp-inverted.local/docs/page';
+
+    server.use(
+      http.get(
+        url,
+        () =>
+          new HttpResponse(html, {
+            status: 200,
+            headers: { 'Content-Type': 'text/html' },
+          }),
+      ),
+    );
+
+    const ctx = makeCtx([{ url, markdown, htmlBody: html }], 'mcp-inverted.local', {
+      parityPassThreshold: 20,
+      parityWarnThreshold: 5,
+    });
+    const result = await check.run(ctx);
+    expect(result.status).toBe('error');
+    expect(result.message).toContain('greater than');
+  });
+
+  it('reports a clear error for invalid CSS selectors in parityExclusions', async () => {
+    const html = `<html><body><main>
+      <h1>Page Title</h1>
+      <p>Content that is long enough to form a meaningful segment for comparison.</p>
+      <p>Additional content that provides enough segments for a valid comparison run.</p>
+      <p>Third paragraph ensures we are above the minimum segment threshold limit.</p>
+      <p>Fourth paragraph provides additional content for the comparison to process.</p>
+      <p>Fifth paragraph rounds out the content to ensure robust segment extraction.</p>
+      <p>Sixth paragraph adds more unique text to exceed the minimum required amount.</p>
+      <p>Seventh paragraph continues to build the content body for a thorough check.</p>
+      <p>Eighth paragraph ensures this page has plenty of content for the check run.</p>
+      <p>Ninth paragraph keeps the content flowing with additional unique text here.</p>
+      <p>Tenth paragraph wraps up the page with one final block of meaningful text.</p>
+    </main></body></html>`;
+    const markdown = '# Page Title\n\nSome markdown content here.';
+    const url = 'http://mcp-bad-selector.local/docs/page';
+
+    server.use(
+      http.get(
+        url,
+        () =>
+          new HttpResponse(html, {
+            status: 200,
+            headers: { 'Content-Type': 'text/html' },
+          }),
+      ),
+    );
+
+    const ctx = makeCtx([{ url, markdown, htmlBody: html }], 'mcp-bad-selector.local', {
+      parityExclusions: ['[data-foo='],
+    });
+    const result = await check.run(ctx);
+    const pageResults = result.details?.pageResults as Array<{ error?: string }>;
+    expect(pageResults[0].error).toContain('Invalid CSS selector');
   });
 });

--- a/test/unit/helpers/config.test.ts
+++ b/test/unit/helpers/config.test.ts
@@ -254,4 +254,88 @@ describe('findConfig', () => {
 
     await expect(findConfig(configPath)).rejects.toThrow('"pages" must be an array');
   });
+
+  it('accepts properly quoted parityExclusions', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    const configPath = resolve(TMP_DIR, 'parity-ok.yml');
+    await writeFile(
+      configPath,
+      [
+        'url: https://example.com',
+        'options:',
+        '  parityExclusions:',
+        '    - .human-only',
+        '    - \'[data-audience="humans"]\'',
+        '',
+      ].join('\n'),
+    );
+
+    const config = await findConfig(configPath);
+    expect(config?.options?.parityExclusions).toEqual(['.human-only', '[data-audience="humans"]']);
+  });
+
+  it('throws when parityExclusions contains unquoted bracket selector', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    const configPath = resolve(TMP_DIR, 'parity-bad.yml');
+    // Unquoted [data-foo] is parsed by YAML as a nested array, not a string
+    await writeFile(
+      configPath,
+      ['url: https://example.com', 'options:', '  parityExclusions:', '    - [data-foo]', ''].join(
+        '\n',
+      ),
+    );
+
+    await expect(findConfig(configPath)).rejects.toThrow('parityExclusions[0] must be a string');
+  });
+
+  it('throws when coverageExclusions contains a non-string entry', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    const configPath = resolve(TMP_DIR, 'coverage-bad.yml');
+    await writeFile(
+      configPath,
+      [
+        'url: https://example.com',
+        'options:',
+        '  coverageExclusions:',
+        '    - [nested-array]',
+        '',
+      ].join('\n'),
+    );
+
+    await expect(findConfig(configPath)).rejects.toThrow('coverageExclusions[0] must be a string');
+  });
+
+  it('validates exclusions in auto-discovered config', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    await writeFile(
+      resolve(TMP_DIR, 'agent-docs.config.yml'),
+      [
+        'url: https://example.com',
+        'options:',
+        '  parityExclusions:',
+        '    - [bad-selector]',
+        '',
+      ].join('\n'),
+    );
+
+    await expect(findConfig(undefined, TMP_DIR)).rejects.toThrow(
+      'parityExclusions[0] must be a string',
+    );
+  });
+
+  it('validates exclusions in loadConfig', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    await writeFile(
+      resolve(TMP_DIR, 'agent-docs.config.yml'),
+      [
+        'url: https://example.com',
+        'options:',
+        '  parityExclusions:',
+        '    - [bad-selector]',
+        '',
+      ].join('\n'),
+    );
+
+    await expect(loadConfig(TMP_DIR)).rejects.toThrow('parityExclusions[0] must be a string');
+  });
 });


### PR DESCRIPTION
## Summary

- Add `data-markdown-ignore` HTML attribute convention for marking human-only content that is intentionally absent from markdown. Elements with this attribute are stripped before comparison so they don't count as "missing."
- Add configurable parity thresholds (`--parity-pass-threshold`, `--parity-warn-threshold`) for sites that intentionally serve different content per audience. Set both to 0 for informational mode. Threshold of 0 means "disabled" rather than "zero tolerance."
- Add `--parity-exclusions` for custom CSS selectors beyond the built-in `data-markdown-ignore` (e.g., platform-specific conventions).
- Validate config file exclusion arrays (`parityExclusions`, `coverageExclusions`) are flat string arrays. Catches the common YAML mistake where unquoted `[data-foo]` is parsed as a nested array instead of a string.
- Error on inverted thresholds (pass > warn) at the check level so lib consumers get validation too.

## Spec driver:

v0.4.0 added audience segmentation support (spec issue [agent-ecosystem/agent-docs-spec#14](https://github.com/agent-ecosystem/agent-docs-spec/issues/14)). Research confirmed that Fern and Mintlify both process their segmentation tags server-side, so the tags never appear in fetched HTML. The implementation uses `data-markdown-ignore` as a new convention that platforms can adopt in their rendered output, plus configurable thresholds as the primary lever for platforms with server-side processing.

## Test plan

- [X] `data-markdown-ignore` elements stripped, content excluded from comparison
- [X] Custom thresholds: 0/0 = informational (always passes, still reports %)
- [X] Custom `parityExclusions` CSS selectors strip matching elements
- [X] Non-default thresholds reported in check details
- [X] Inverted thresholds (pass > warn) return error status
- [X] Invalid CSS selector in exclusions produces clear error message
- [X] Config validation catches unquoted bracket selectors in YAML
- [X] Config validation covers all three load paths (explicit, auto-discover, loadConfig)
- [X] All 954 tests pass, lint clean, build clean

