### PR TITLE
Add shared validation module for CLI and library consumers

### DIFF
--- a/docs/reference/programmatic-api.md
+++ b/docs/reference/programmatic-api.md
@@ -17,7 +17,7 @@ for (const result of report.results) {
 }
 ```
 
-`runChecks` returns a `ReportResult` containing:
+`runChecks` throws an `Error` if the options are invalid (see [Validate options](#validate-options) below). On success, it returns a `ReportResult` containing:
 
 - `url` — the URL that was checked
 - `timestamp` — when the check ran
@@ -78,7 +78,7 @@ console.log(result.status); // 'pass', 'warn', 'fail', or 'skip'
 console.log(result.message);
 ```
 
-`createContext` sets up the shared state (HTTP client, page cache, previous results) that checks use. If you run multiple checks against the same context, later checks can access the results of earlier ones through `ctx.previousResults`, which is how check dependencies work.
+`createContext` validates the options and throws an `Error` if any are invalid, then sets up the shared state (HTTP client, page cache, previous results) that checks use. If you run multiple checks against the same context, later checks can access the results of earlier ones through `ctx.previousResults`, which is how check dependencies work.
 
 ## List available checks
 
@@ -93,6 +93,42 @@ const sorted = getChecksSorted();
 for (const check of sorted) {
   console.log(`${check.id} (${check.category}): ${check.description}`);
 }
+```
+
+## Validate options
+
+Both `runChecks` and `createContext` validate options and throw on invalid input. If you want to check options before calling either function (for example, to show validation errors in a UI or dry-run mode), use `validateRunnerOptions`:
+
+```ts
+import { validateRunnerOptions } from 'afdocs';
+
+const validation = validateRunnerOptions({
+  maxConcurrency: -1,
+  samplingStrategy: 'curated',
+});
+
+if (!validation.valid) {
+  for (const error of validation.errors) {
+    console.error(`${error.field}: ${error.message}`);
+    // maxConcurrency: maxConcurrency must be between 1 and 100, got -1
+    // samplingStrategy: Curated sampling requires curatedPages to be non-empty
+  }
+}
+```
+
+`validateRunnerOptions` returns a `ValidationResult` with `errors` and `warnings` arrays. Each entry has a `field` (the option name) and a `message` (human-readable description). The `valid` boolean is `true` when there are no errors.
+
+Validations performed include numeric range checking, threshold ordering (e.g. size pass threshold must be less than or equal to fail threshold), sampling strategy enum validation, and check ID existence.
+
+## Sampling strategies
+
+The valid sampling strategies are available as a constant:
+
+```ts
+import { VALID_SAMPLING_STRATEGIES } from 'afdocs';
+
+console.log(VALID_SAMPLING_STRATEGIES);
+// ['random', 'deterministic', 'curated', 'none']
 ```
 
 ## Types
@@ -110,6 +146,8 @@ import type {
   AgentDocsConfig,
   CuratedPageEntry,
   PageConfigEntry,
+  ValidationResult,
+  ValidationIssue,
 } from 'afdocs';
 ```
 

--- a/src/checks/observability/llms-txt-coverage.ts
+++ b/src/checks/observability/llms-txt-coverage.ts
@@ -315,19 +315,10 @@ async function check(ctx: CheckContext): Promise<CheckResult> {
   const id = 'llms-txt-coverage';
   const category = 'observability';
 
-  // Resolve thresholds: CLI/config overrides → defaults, clamped to [0, 100]
-  const clamp = (v: number) => Math.max(0, Math.min(100, v));
-  const rawPass = ctx.options.coveragePassThreshold ?? DEFAULT_COVERAGE_PASS_THRESHOLD;
-  const rawWarn = ctx.options.coverageWarnThreshold ?? DEFAULT_COVERAGE_WARN_THRESHOLD;
-  const passThreshold = clamp(rawPass) / 100;
-  const warnThreshold = clamp(rawWarn) / 100;
-  const thresholdWarnings: string[] = [];
-  if (passThreshold < warnThreshold) {
-    thresholdWarnings.push(
-      `coveragePassThreshold (${clamp(rawPass)}) is lower than ` +
-        `coverageWarnThreshold (${clamp(rawWarn)}); warn state is unreachable`,
-    );
-  }
+  const passThreshold =
+    (ctx.options.coveragePassThreshold ?? DEFAULT_COVERAGE_PASS_THRESHOLD) / 100;
+  const warnThreshold =
+    (ctx.options.coverageWarnThreshold ?? DEFAULT_COVERAGE_WARN_THRESHOLD) / 100;
 
   // Compile user-supplied exclusion patterns
   const userExclusionMatcher = compileExclusionMatcher(ctx.options.coverageExclusions ?? []);
@@ -561,7 +552,6 @@ async function check(ctx: CheckContext): Promise<CheckResult> {
       unmatchedCount: unmatchedLlmsTxtUrls.length,
       unmatchedPct,
       sitemapWarnings,
-      ...(thresholdWarnings.length > 0 ? { thresholdWarnings } : {}),
     },
   };
 }

--- a/src/checks/observability/markdown-content-parity.ts
+++ b/src/checks/observability/markdown-content-parity.ts
@@ -651,18 +651,6 @@ async function check(ctx: CheckContext): Promise<CheckResult> {
   const failThreshold = ctx.options.parityWarnThreshold ?? DEFAULT_PARITY_WARN_THRESHOLD;
   const parityExclusions = ctx.options.parityExclusions;
 
-  if (warnThreshold > failThreshold && failThreshold > 0) {
-    return {
-      id,
-      category,
-      status: 'error',
-      message:
-        `parityPassThreshold (${warnThreshold}) is greater than ` +
-        `parityWarnThreshold (${failThreshold}). The pass threshold must be ` +
-        'less than or equal to the warn threshold.',
-    };
-  }
-
   const results: PageParityResult[] = [];
   const concurrency = ctx.options.maxConcurrency;
   let totalSegmentationStripped = 0;

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -3,13 +3,13 @@ import { normalizeUrl, runChecks } from '../../runner.js';
 import { formatText } from '../formatters/text.js';
 import { formatJson } from '../formatters/json.js';
 import { formatScorecard } from '../formatters/scorecard.js';
-import type { PageConfigEntry, SamplingStrategy } from '../../types.js';
+import type { PageConfigEntry, RunnerOptions, SamplingStrategy } from '../../types.js';
 import { findConfig, validatePages } from '../../helpers/config.js';
+import { validateRunnerOptions } from '../../validation.js';
 
 // Ensure all checks are registered
 import '../../checks/index.js';
 
-const SAMPLING_STRATEGIES = ['random', 'deterministic', 'curated', 'none'] as const;
 const FORMAT_OPTIONS = ['text', 'json', 'scorecard'] as const;
 
 export function registerCheckCommand(program: Command): void {
@@ -152,21 +152,6 @@ export function registerCheckCommand(program: Command): void {
       }
 
       const sampling = samplingRaw as SamplingStrategy;
-      if (!SAMPLING_STRATEGIES.includes(sampling)) {
-        process.stderr.write(
-          `Error: Invalid sampling strategy "${sampling}". Must be one of: ${SAMPLING_STRATEGIES.join(', ')}\n`,
-        );
-        process.exitCode = 1;
-        return;
-      }
-
-      if (sampling === 'curated' && (!curatedPages || curatedPages.length === 0)) {
-        process.stderr.write(
-          'Error: Curated sampling requires pages. Use --urls or define "pages" in your config file.\n',
-        );
-        process.exitCode = 1;
-        return;
-      }
 
       const maxConcurrency = parseInt(
         String((opts.maxConcurrency as string | undefined) ?? config?.options?.maxConcurrency ?? 3),
@@ -211,37 +196,35 @@ export function registerCheckCommand(program: Command): void {
       const rawCanonical =
         (opts.canonicalOrigin as string | undefined) ?? config?.options?.canonicalOrigin;
       if (rawCanonical) {
+        const normalized = normalizeUrl(rawCanonical);
         try {
-          canonicalOrigin = new URL(normalizeUrl(rawCanonical)).origin;
+          canonicalOrigin = new URL(normalized).origin;
+          const targetOrigin = new URL(url).origin;
+          if (canonicalOrigin === targetOrigin) {
+            process.stderr.write(
+              `Warning: --canonical-origin "${canonicalOrigin}" is the same as the target origin. The flag has no effect.\n`,
+            );
+            canonicalOrigin = undefined;
+          }
         } catch {
-          process.stderr.write(`Error: Invalid --canonical-origin URL "${rawCanonical}".\n`);
-          process.exitCode = 1;
-          return;
-        }
-        const targetOrigin = new URL(url).origin;
-        if (canonicalOrigin === targetOrigin) {
-          process.stderr.write(
-            `Warning: --canonical-origin "${canonicalOrigin}" is the same as the target origin. The flag has no effect.\n`,
-          );
-          canonicalOrigin = undefined;
+          canonicalOrigin = normalized;
         }
       }
 
       let llmsTxtUrl: string | undefined;
       const rawLlmsTxtUrl = (opts.llmsTxtUrl as string | undefined) ?? config?.options?.llmsTxtUrl;
       if (rawLlmsTxtUrl) {
+        const normalized = normalizeUrl(rawLlmsTxtUrl);
         try {
-          llmsTxtUrl = new URL(normalizeUrl(rawLlmsTxtUrl)).toString();
+          llmsTxtUrl = new URL(normalized).toString();
+          const targetOrigin = new URL(url).origin;
+          if (new URL(llmsTxtUrl).origin !== targetOrigin) {
+            process.stderr.write(
+              `Warning: --llms-txt-url origin (${new URL(llmsTxtUrl).origin}) differs from target origin (${targetOrigin}). The flag will still be used as canonical.\n`,
+            );
+          }
         } catch {
-          process.stderr.write(`Error: Invalid --llms-txt-url "${rawLlmsTxtUrl}".\n`);
-          process.exitCode = 1;
-          return;
-        }
-        const targetOrigin = new URL(url).origin;
-        if (new URL(llmsTxtUrl).origin !== targetOrigin) {
-          process.stderr.write(
-            `Warning: --llms-txt-url origin (${new URL(llmsTxtUrl).origin}) differs from target origin (${targetOrigin}). The flag will still be used as canonical.\n`,
-          );
+          llmsTxtUrl = normalized;
         }
       }
 
@@ -279,7 +262,7 @@ export function registerCheckCommand(program: Command): void {
               .filter(Boolean)
           : (config?.options?.parityExclusions ?? undefined);
 
-      const report = await runChecks(url, {
+      const runnerOptions: Partial<RunnerOptions> = {
         checkIds,
         skipCheckIds,
         maxConcurrency,
@@ -301,7 +284,21 @@ export function registerCheckCommand(program: Command): void {
         ...(parityPassThreshold != null && { parityPassThreshold }),
         ...(parityWarnThreshold != null && { parityWarnThreshold }),
         ...(parityExclusions && { parityExclusions }),
-      });
+      };
+
+      const validation = validateRunnerOptions(runnerOptions);
+      if (!validation.valid) {
+        for (const err of validation.errors) {
+          process.stderr.write(`Error: ${err.message}\n`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+      for (const warn of validation.warnings) {
+        process.stderr.write(`Warning: ${warn.message}\n`);
+      }
+
+      const report = await runChecks(url, runnerOptions);
 
       let output: string;
       if (format === 'json') {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,11 @@
-import type { CheckOptions, SizeThresholds } from './types.js';
+import type { CheckOptions, SamplingStrategy, SizeThresholds } from './types.js';
+
+export const VALID_SAMPLING_STRATEGIES: readonly SamplingStrategy[] = [
+  'random',
+  'deterministic',
+  'curated',
+  'none',
+];
 
 export const DEFAULT_THRESHOLDS: SizeThresholds = {
   pass: 50_000,

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -2,6 +2,8 @@ import { readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import type { AgentDocsConfig, PageConfigEntry } from '../types.js';
+import { validateNumber } from '../validation.js';
+import { VALID_SAMPLING_STRATEGIES } from '../constants.js';
 
 const CONFIG_FILENAMES = ['agent-docs.config.yml', 'agent-docs.config.yaml'];
 
@@ -58,12 +60,74 @@ function validateStringArray(value: unknown, field: string, source: string): voi
   }
 }
 
+const NUMERIC_OPTION_RULES: [string, { integer?: boolean; min?: number; max?: number }][] = [
+  ['maxConcurrency', { integer: true, min: 1, max: 100 }],
+  ['requestDelay', { integer: true, min: 0 }],
+  ['requestTimeout', { integer: true, min: 0 }],
+  ['maxLinksToTest', { integer: true, min: 1 }],
+  ['coveragePassThreshold', { integer: true, min: 0, max: 100 }],
+  ['coverageWarnThreshold', { integer: true, min: 0, max: 100 }],
+  ['parityPassThreshold', { integer: true, min: 0, max: 100 }],
+  ['parityWarnThreshold', { integer: true, min: 0, max: 100 }],
+];
+
 function validateOptions(options: Record<string, unknown>, source: string): void {
   if (options.coverageExclusions != null) {
     validateStringArray(options.coverageExclusions, 'options.coverageExclusions', source);
   }
   if (options.parityExclusions != null) {
     validateStringArray(options.parityExclusions, 'options.parityExclusions', source);
+  }
+  if (
+    options.samplingStrategy != null &&
+    !VALID_SAMPLING_STRATEGIES.includes(
+      options.samplingStrategy as string as (typeof VALID_SAMPLING_STRATEGIES)[number],
+    )
+  ) {
+    throw new Error(
+      `${source}: options.samplingStrategy must be one of: ${VALID_SAMPLING_STRATEGIES.join(', ')}`,
+    );
+  }
+  for (const [field, constraints] of NUMERIC_OPTION_RULES) {
+    if (options[field] != null) {
+      const issue = validateNumber(options[field], `options.${field}`, constraints);
+      if (issue) {
+        throw new Error(`${source}: ${issue.message}`);
+      }
+    }
+  }
+  if (options.thresholds != null) {
+    const thresholds = options.thresholds as Record<string, unknown>;
+    if (thresholds.pass != null) {
+      const issue = validateNumber(thresholds.pass, 'options.thresholds.pass', {
+        integer: true,
+        min: 1,
+      });
+      if (issue) throw new Error(`${source}: ${issue.message}`);
+    }
+    if (thresholds.fail != null) {
+      const issue = validateNumber(thresholds.fail, 'options.thresholds.fail', {
+        integer: true,
+        min: 1,
+      });
+      if (issue) throw new Error(`${source}: ${issue.message}`);
+    }
+  }
+}
+
+function validateConfig(parsed: AgentDocsConfig, source: string): void {
+  if (parsed.checks != null) {
+    validateStringArray(parsed.checks, 'checks', source);
+  }
+  if (parsed.skipChecks != null) {
+    validateStringArray(parsed.skipChecks, 'skipChecks', source);
+  }
+  if (parsed.pages) {
+    assertPagesArray(parsed.pages, source);
+    validatePages(parsed.pages, source);
+  }
+  if (parsed.options) {
+    validateOptions(parsed.options as Record<string, unknown>, source);
   }
 }
 
@@ -84,13 +148,7 @@ export async function loadConfig(dir?: string): Promise<AgentDocsConfig> {
         if (!parsed.url) {
           throw new Error(`Config file ${filepath} is missing required "url" field`);
         }
-        if (parsed.pages) {
-          assertPagesArray(parsed.pages, filepath);
-          validatePages(parsed.pages, filepath);
-        }
-        if (parsed.options) {
-          validateOptions(parsed.options as Record<string, unknown>, filepath);
-        }
+        validateConfig(parsed, filepath);
         return parsed;
       } catch (err) {
         if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
@@ -123,13 +181,7 @@ export async function findConfig(
     const filepath = resolve(process.cwd(), explicitPath);
     const content = await readFile(filepath, 'utf-8');
     const parsed = parseYaml(content) as AgentDocsConfig;
-    if (parsed.pages) {
-      assertPagesArray(parsed.pages, filepath);
-      validatePages(parsed.pages, filepath);
-    }
-    if (parsed.options) {
-      validateOptions(parsed.options as Record<string, unknown>, filepath);
-    }
+    validateConfig(parsed, filepath);
     return parsed;
   }
 
@@ -140,13 +192,7 @@ export async function findConfig(
       try {
         const content = await readFile(filepath, 'utf-8');
         const parsed = parseYaml(content) as AgentDocsConfig;
-        if (parsed.pages) {
-          assertPagesArray(parsed.pages, filepath);
-          validatePages(parsed.pages, filepath);
-        }
-        if (parsed.options) {
-          validateOptions(parsed.options as Record<string, unknown>, filepath);
-        }
+        validateConfig(parsed, filepath);
         return parsed;
       } catch (err) {
         if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,14 @@ export type {
   PageConfigEntry,
 } from './types.js';
 
-export { DEFAULT_OPTIONS, DEFAULT_THRESHOLDS, CATEGORIES } from './constants.js';
+export {
+  DEFAULT_OPTIONS,
+  DEFAULT_THRESHOLDS,
+  CATEGORIES,
+  VALID_SAMPLING_STRATEGIES,
+} from './constants.js';
+export { validateRunnerOptions } from './validation.js';
+export type { ValidationResult, ValidationIssue } from './validation.js';
 export { createContext, normalizeUrl, runChecks } from './runner.js';
 export { createHttpClient } from './http.js';
 export { getAllChecks, getCheck, getChecksSorted, extractMarkdownLinks } from './checks/index.js';

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -2,6 +2,7 @@ import type { CheckContext, CheckResult, RunnerOptions, ReportResult } from './t
 import { DEFAULT_OPTIONS, SPEC_BASE_URL } from './constants.js';
 import { createHttpClient } from './http.js';
 import { getChecksSorted } from './checks/registry.js';
+import { validateRunnerOptions } from './validation.js';
 
 /**
  * Normalize dependsOn to the internal format: array of OR-groups.
@@ -41,6 +42,20 @@ export function normalizeUrl(url: string): string {
 }
 
 export function createContext(baseUrl: string, options?: Partial<RunnerOptions>): CheckContext {
+  if (options) {
+    if (options.canonicalOrigin) {
+      options = { ...options, canonicalOrigin: normalizeUrl(options.canonicalOrigin) };
+    }
+    if (options.llmsTxtUrl) {
+      options = { ...options, llmsTxtUrl: normalizeUrl(options.llmsTxtUrl) };
+    }
+    const validation = validateRunnerOptions(options);
+    if (!validation.valid) {
+      const messages = validation.errors.map((e) => `${e.field}: ${e.message}`);
+      throw new Error(`Invalid options: ${messages.join('; ')}`);
+    }
+  }
+
   const merged = { ...DEFAULT_OPTIONS, ...options };
   baseUrl = normalizeUrl(baseUrl);
   const url = new URL(baseUrl);

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,0 +1,219 @@
+import type { RunnerOptions, SamplingStrategy } from './types.js';
+import { VALID_SAMPLING_STRATEGIES } from './constants.js';
+import { getAllChecks } from './checks/registry.js';
+
+export interface ValidationIssue {
+  field: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationIssue[];
+  warnings: ValidationIssue[];
+}
+
+export interface NumericConstraints {
+  integer?: boolean;
+  min?: number;
+  max?: number;
+}
+
+export function validateNumber(
+  value: unknown,
+  field: string,
+  constraints: NumericConstraints,
+): ValidationIssue | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return {
+      field,
+      message: `${field} must be a valid number, got ${typeof value === 'number' ? 'NaN' : `${typeof value} "${value}"`}`,
+    };
+  }
+  if (constraints.integer && !Number.isInteger(value)) {
+    return { field, message: `${field} must be an integer, got ${value}` };
+  }
+  if (constraints.min !== undefined && value < constraints.min) {
+    const bound =
+      constraints.max !== undefined
+        ? `between ${constraints.min} and ${constraints.max}`
+        : `at least ${constraints.min}`;
+    return { field, message: `${field} must be ${bound}, got ${value}` };
+  }
+  if (constraints.max !== undefined && value > constraints.max) {
+    const bound =
+      constraints.min !== undefined
+        ? `between ${constraints.min} and ${constraints.max}`
+        : `at most ${constraints.max}`;
+    return { field, message: `${field} must be ${bound}, got ${value}` };
+  }
+  return null;
+}
+
+function validateUrl(value: unknown, field: string): ValidationIssue | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'string') {
+    return { field, message: `${field} must be a string` };
+  }
+  try {
+    new URL(value);
+    return null;
+  } catch {
+    return { field, message: `${field} is not a valid URL: "${value}"` };
+  }
+}
+
+export function validateRunnerOptions(options: Partial<RunnerOptions>): ValidationResult {
+  const errors: ValidationIssue[] = [];
+  const warnings: ValidationIssue[] = [];
+
+  const pushError = (issue: ValidationIssue | null) => {
+    if (issue) errors.push(issue);
+  };
+
+  // Numeric range validations
+  pushError(
+    validateNumber(options.maxConcurrency, 'maxConcurrency', { integer: true, min: 1, max: 100 }),
+  );
+  pushError(validateNumber(options.requestDelay, 'requestDelay', { integer: true, min: 0 }));
+  pushError(validateNumber(options.requestTimeout, 'requestTimeout', { integer: true, min: 0 }));
+  pushError(validateNumber(options.maxLinksToTest, 'maxLinksToTest', { integer: true, min: 1 }));
+
+  if (options.thresholds) {
+    pushError(
+      validateNumber(options.thresholds.pass, 'thresholds.pass', { integer: true, min: 1 }),
+    );
+    pushError(
+      validateNumber(options.thresholds.fail, 'thresholds.fail', { integer: true, min: 1 }),
+    );
+  }
+
+  pushError(
+    validateNumber(options.coveragePassThreshold, 'coveragePassThreshold', {
+      integer: true,
+      min: 0,
+      max: 100,
+    }),
+  );
+  pushError(
+    validateNumber(options.coverageWarnThreshold, 'coverageWarnThreshold', {
+      integer: true,
+      min: 0,
+      max: 100,
+    }),
+  );
+  pushError(
+    validateNumber(options.parityPassThreshold, 'parityPassThreshold', {
+      integer: true,
+      min: 0,
+      max: 100,
+    }),
+  );
+  pushError(
+    validateNumber(options.parityWarnThreshold, 'parityWarnThreshold', {
+      integer: true,
+      min: 0,
+      max: 100,
+    }),
+  );
+
+  // Threshold ordering (only when both in a pair are provided and individually valid)
+  if (
+    options.thresholds &&
+    typeof options.thresholds.pass === 'number' &&
+    typeof options.thresholds.fail === 'number' &&
+    !Number.isNaN(options.thresholds.pass) &&
+    !Number.isNaN(options.thresholds.fail) &&
+    options.thresholds.pass > options.thresholds.fail
+  ) {
+    errors.push({
+      field: 'thresholds',
+      message: `thresholds.pass (${options.thresholds.pass}) must be less than or equal to thresholds.fail (${options.thresholds.fail})`,
+    });
+  }
+
+  if (
+    options.coveragePassThreshold !== undefined &&
+    options.coverageWarnThreshold !== undefined &&
+    !Number.isNaN(options.coveragePassThreshold) &&
+    !Number.isNaN(options.coverageWarnThreshold) &&
+    options.coveragePassThreshold < options.coverageWarnThreshold
+  ) {
+    errors.push({
+      field: 'coveragePassThreshold',
+      message: `coveragePassThreshold (${options.coveragePassThreshold}) must be greater than or equal to coverageWarnThreshold (${options.coverageWarnThreshold})`,
+    });
+  }
+
+  if (
+    options.parityPassThreshold !== undefined &&
+    options.parityWarnThreshold !== undefined &&
+    !Number.isNaN(options.parityPassThreshold) &&
+    !Number.isNaN(options.parityWarnThreshold) &&
+    options.parityPassThreshold > options.parityWarnThreshold
+  ) {
+    errors.push({
+      field: 'parityPassThreshold',
+      message: `parityPassThreshold (${options.parityPassThreshold}) must be less than or equal to parityWarnThreshold (${options.parityWarnThreshold})`,
+    });
+  }
+
+  // Sampling strategy enum
+  if (
+    options.samplingStrategy !== undefined &&
+    !VALID_SAMPLING_STRATEGIES.includes(options.samplingStrategy as SamplingStrategy)
+  ) {
+    errors.push({
+      field: 'samplingStrategy',
+      message: `Invalid sampling strategy "${options.samplingStrategy}". Must be one of: ${VALID_SAMPLING_STRATEGIES.join(', ')}`,
+    });
+  }
+
+  // Curated requires pages
+  if (
+    options.samplingStrategy === 'curated' &&
+    (!options.curatedPages || options.curatedPages.length === 0)
+  ) {
+    errors.push({
+      field: 'samplingStrategy',
+      message: 'Curated sampling requires curatedPages to be non-empty',
+    });
+  }
+
+  // URL validation
+  pushError(validateUrl(options.canonicalOrigin, 'canonicalOrigin'));
+  pushError(validateUrl(options.llmsTxtUrl, 'llmsTxtUrl'));
+
+  // Check ID validation
+  if (
+    (options.checkIds && options.checkIds.length > 0) ||
+    (options.skipCheckIds && options.skipCheckIds.length > 0)
+  ) {
+    const knownIds = getAllChecks().map((c) => c.id);
+    const knownSet = new Set(knownIds);
+
+    const validateCheckId = (id: string, field: string) => {
+      if (knownSet.has(id)) return;
+      const sortedIds = [...knownIds].sort();
+      const hint = sortedIds.join(', ');
+      errors.push({
+        field,
+        message: `Unknown check ID "${id}". Available checks: ${hint}`,
+      });
+    };
+
+    if (options.checkIds) {
+      for (const id of options.checkIds) validateCheckId(id, 'checkIds');
+    }
+    if (options.skipCheckIds) {
+      for (const id of options.skipCheckIds) validateCheckId(id, 'skipCheckIds');
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}

--- a/test/unit/checks/llms-txt-coverage.test.ts
+++ b/test/unit/checks/llms-txt-coverage.test.ts
@@ -798,36 +798,6 @@ describe('filterToUnprefixedLocale', () => {
 });
 
 describe('edge cases', () => {
-  test('warns when passThreshold < warnThreshold', async () => {
-    const host = 'cov-threshold-warn.local';
-    const allPages = Array.from({ length: 10 }, (_, i) => `http://${host}/docs/page-${i}`);
-    const llmsPages = allPages.slice(0, 9);
-
-    const ctx = makeCtx(host, llmsPages, '/docs');
-    ctx.options.coveragePassThreshold = 50;
-    ctx.options.coverageWarnThreshold = 80;
-
-    server.use(
-      http.get(
-        `http://${host}/robots.txt`,
-        () => new HttpResponse(`Sitemap: http://${host}/sitemap.xml`, { status: 200 }),
-      ),
-      http.get(
-        `http://${host}/sitemap.xml`,
-        () =>
-          new HttpResponse(makeSitemap(allPages), {
-            status: 200,
-            headers: { 'content-type': 'application/xml' },
-          }),
-      ),
-    );
-
-    const result = await check.run(ctx);
-    expect(result.details?.thresholdWarnings).toBeDefined();
-    const warnings = result.details?.thresholdWarnings as string[];
-    expect(warnings[0]).toContain('warn state is unreachable');
-  });
-
   test('handles malformed URLs in sitemap gracefully', async () => {
     const host = 'cov-malformed.local';
     const goodPages = [`http://${host}/docs/guide`];

--- a/test/unit/checks/markdown-content-parity.test.ts
+++ b/test/unit/checks/markdown-content-parity.test.ts
@@ -2052,32 +2052,6 @@ All requests are authenticated automatically using the configured API credential
     expect(result.details?.parityWarnThreshold).toBe(30);
   });
 
-  it('returns error when parityPassThreshold exceeds parityWarnThreshold', async () => {
-    const html =
-      '<html><body><h1>Page</h1><p>Content that matches between HTML and markdown versions exactly.</p></body></html>';
-    const markdown = '# Page\n\nContent that matches between HTML and markdown versions exactly.';
-    const url = 'http://mcp-inverted.local/docs/page';
-
-    server.use(
-      http.get(
-        url,
-        () =>
-          new HttpResponse(html, {
-            status: 200,
-            headers: { 'Content-Type': 'text/html' },
-          }),
-      ),
-    );
-
-    const ctx = makeCtx([{ url, markdown, htmlBody: html }], 'mcp-inverted.local', {
-      parityPassThreshold: 20,
-      parityWarnThreshold: 5,
-    });
-    const result = await check.run(ctx);
-    expect(result.status).toBe('error');
-    expect(result.message).toContain('greater than');
-  });
-
   it('reports a clear error for invalid CSS selectors in parityExclusions', async () => {
     const html = `<html><body><main>
       <h1>Page Title</h1>

--- a/test/unit/cli/check-command.test.ts
+++ b/test/unit/cli/check-command.test.ts
@@ -3,6 +3,7 @@ import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { writeFile, mkdir, rm } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import * as validationMod from '../../../src/validation.js';
 
 const VALID_LLMS_TXT = `# Test
 
@@ -423,7 +424,7 @@ describe('check command config integration', () => {
     await new Promise((r) => setTimeout(r, 100));
 
     const output = stderrSpy.mock.calls.map((c) => c[0]).join('');
-    expect(output).toContain('Curated sampling requires pages');
+    expect(output).toContain('Curated sampling requires curatedPages to be non-empty');
     expect(process.exitCode).toBe(1);
 
     stderrSpy.mockRestore();
@@ -631,7 +632,7 @@ describe('check command config integration', () => {
     await new Promise((r) => setTimeout(r, 100));
 
     const output = stderrSpy.mock.calls.map((c) => c[0]).join('');
-    expect(output).toContain('Invalid --llms-txt-url');
+    expect(output).toContain('llmsTxtUrl is not a valid URL');
     expect(process.exitCode).toBe(1);
 
     stderrSpy.mockRestore();
@@ -672,6 +673,229 @@ describe('check command config integration', () => {
     const parsed = JSON.parse(stdout.trim());
     expect(parsed.results[0].details.canonicalUrl).toBe('http://other.local/custom/llms.txt');
 
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('errors when config file is invalid YAML', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const configPath = resolve(CONFIG_TMP, 'bad-config.yml');
+    await writeFile(configPath, ':\ninvalid: [yaml\n');
+
+    const { run } = await import('../../../src/cli/index.js');
+    await run(['node', 'afdocs', 'check', '--config', configPath, '--request-delay', '0']);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const output = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    expect(output).toContain('Error:');
+    expect(process.exitCode).toBe(1);
+
+    stderrSpy.mockRestore();
+  });
+
+  it('parses --skip-checks flag', async () => {
+    server.use(
+      http.get('http://cmd-skip.local/llms.txt', () => HttpResponse.text(VALID_LLMS_TXT)),
+      http.get(
+        'http://cmd-skip.local/docs/llms.txt',
+        () => new HttpResponse(null, { status: 404 }),
+      ),
+    );
+
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const { run } = await import('../../../src/cli/index.js');
+    await run([
+      'node',
+      'afdocs',
+      'check',
+      'http://cmd-skip.local',
+      '--checks',
+      'llms-txt-exists,llms-txt-valid',
+      '--skip-checks',
+      'llms-txt-valid',
+      '--format',
+      'json',
+      '--request-delay',
+      '0',
+    ]);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const output = writeSpy.mock.calls.map((c) => c[0]).join('');
+    const parsed = JSON.parse(output.trim());
+    const skipped = parsed.results.find((r: { id: string }) => r.id === 'llms-txt-valid');
+    expect(skipped.status).toBe('skip');
+
+    writeSpy.mockRestore();
+  });
+
+  it('warns when --canonical-origin matches target origin', async () => {
+    server.use(
+      http.get('http://cmd-canon-same.local/llms.txt', () => HttpResponse.text(VALID_LLMS_TXT)),
+      http.get(
+        'http://cmd-canon-same.local/docs/llms.txt',
+        () => new HttpResponse(null, { status: 404 }),
+      ),
+    );
+
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const { run } = await import('../../../src/cli/index.js');
+    await run([
+      'node',
+      'afdocs',
+      'check',
+      'http://cmd-canon-same.local',
+      '--canonical-origin',
+      'http://cmd-canon-same.local',
+      '--checks',
+      'llms-txt-exists',
+      '--request-delay',
+      '0',
+    ]);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const stderr = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    expect(stderr).toContain('same as the target origin');
+    expect(stderr).toContain('no effect');
+
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('falls through invalid --canonical-origin to validation', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const { run } = await import('../../../src/cli/index.js');
+    await run([
+      'node',
+      'afdocs',
+      'check',
+      'http://cmd-canon-bad.local',
+      '--canonical-origin',
+      ':::not-a-url:::',
+      '--checks',
+      'llms-txt-exists',
+      '--request-delay',
+      '0',
+    ]);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const output = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    expect(output).toContain('canonicalOrigin');
+    expect(output).toContain('not a valid URL');
+    expect(process.exitCode).toBe(1);
+
+    stderrSpy.mockRestore();
+  });
+
+  it('passes --coverage-exclusions to runner', async () => {
+    server.use(
+      http.get('http://cmd-cov-excl.local/llms.txt', () => HttpResponse.text(VALID_LLMS_TXT)),
+      http.get(
+        'http://cmd-cov-excl.local/docs/llms.txt',
+        () => new HttpResponse(null, { status: 404 }),
+      ),
+    );
+
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const { run } = await import('../../../src/cli/index.js');
+    await run([
+      'node',
+      'afdocs',
+      'check',
+      'http://cmd-cov-excl.local',
+      '--checks',
+      'llms-txt-exists',
+      '--coverage-exclusions',
+      '/docs/ref/**,/docs/changelog/**',
+      '--format',
+      'json',
+      '--request-delay',
+      '0',
+    ]);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const output = writeSpy.mock.calls.map((c) => c[0]).join('');
+    const parsed = JSON.parse(output.trim());
+    expect(parsed.results[0].status).toBe('pass');
+
+    writeSpy.mockRestore();
+  });
+
+  it('passes --parity-exclusions to runner', async () => {
+    server.use(
+      http.get('http://cmd-par-excl.local/llms.txt', () => HttpResponse.text(VALID_LLMS_TXT)),
+      http.get(
+        'http://cmd-par-excl.local/docs/llms.txt',
+        () => new HttpResponse(null, { status: 404 }),
+      ),
+    );
+
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const { run } = await import('../../../src/cli/index.js');
+    await run([
+      'node',
+      'afdocs',
+      'check',
+      'http://cmd-par-excl.local',
+      '--checks',
+      'llms-txt-exists',
+      '--parity-exclusions',
+      '.nav-content,[data-human-only]',
+      '--format',
+      'json',
+      '--request-delay',
+      '0',
+    ]);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const output = writeSpy.mock.calls.map((c) => c[0]).join('');
+    const parsed = JSON.parse(output.trim());
+    expect(parsed.results[0].status).toBe('pass');
+
+    writeSpy.mockRestore();
+  });
+
+  it('displays validation warnings on stderr', async () => {
+    server.use(
+      http.get('http://cmd-warn.local/llms.txt', () => HttpResponse.text(VALID_LLMS_TXT)),
+      http.get(
+        'http://cmd-warn.local/docs/llms.txt',
+        () => new HttpResponse(null, { status: 404 }),
+      ),
+    );
+
+    const spy = vi.spyOn(validationMod, 'validateRunnerOptions').mockReturnValueOnce({
+      valid: true,
+      errors: [],
+      warnings: [{ field: 'testField', message: 'This is a test warning' }],
+    });
+
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const { run } = await import('../../../src/cli/index.js');
+    await run([
+      'node',
+      'afdocs',
+      'check',
+      'http://cmd-warn.local',
+      '--checks',
+      'llms-txt-exists',
+      '--request-delay',
+      '0',
+    ]);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const stderr = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    expect(stderr).toContain('Warning: This is a test warning');
+
+    spy.mockRestore();
     stdoutSpy.mockRestore();
     stderrSpy.mockRestore();
   });

--- a/test/unit/helpers/config.test.ts
+++ b/test/unit/helpers/config.test.ts
@@ -247,6 +247,25 @@ describe('findConfig', () => {
     await expect(findConfig(configPath)).rejects.toThrow('pages[0] must be a URL string or');
   });
 
+  it('throws on invalid URL in pages object url field', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    const configPath = resolve(TMP_DIR, 'bad-obj-url.yml');
+    await writeFile(configPath, 'url: https://example.com\npages:\n  - url: not-a-valid-url\n');
+
+    await expect(findConfig(configPath)).rejects.toThrow('pages[0].url is not a valid URL');
+  });
+
+  it('throws on non-string tag in pages object entry', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    const configPath = resolve(TMP_DIR, 'bad-tag.yml');
+    await writeFile(
+      configPath,
+      'url: https://example.com\npages:\n  - url: https://example.com/a\n    tag: 42\n',
+    );
+
+    await expect(findConfig(configPath)).rejects.toThrow('pages[0].tag must be a string');
+  });
+
   it('throws when pages is a scalar instead of an array', async () => {
     await mkdir(TMP_DIR, { recursive: true });
     const configPath = resolve(TMP_DIR, 'scalar-pages.yml');
@@ -337,5 +356,150 @@ describe('findConfig', () => {
     );
 
     await expect(loadConfig(TMP_DIR)).rejects.toThrow('parityExclusions[0] must be a string');
+  });
+
+  it('throws on invalid numeric option in config', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    await writeFile(
+      resolve(TMP_DIR, 'agent-docs.config.yml'),
+      ['url: https://example.com', 'options:', '  maxConcurrency: -5', ''].join('\n'),
+    );
+
+    await expect(findConfig(undefined, TMP_DIR)).rejects.toThrow('options.maxConcurrency');
+  });
+
+  it('throws on non-numeric option value in config', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    await writeFile(
+      resolve(TMP_DIR, 'agent-docs.config.yml'),
+      ['url: https://example.com', 'options:', '  maxConcurrency: fast', ''].join('\n'),
+    );
+
+    await expect(findConfig(undefined, TMP_DIR)).rejects.toThrow('options.maxConcurrency');
+  });
+
+  it('throws on out-of-range coverage threshold in config', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    await writeFile(
+      resolve(TMP_DIR, 'agent-docs.config.yml'),
+      ['url: https://example.com', 'options:', '  coveragePassThreshold: 150', ''].join('\n'),
+    );
+
+    await expect(findConfig(undefined, TMP_DIR)).rejects.toThrow('options.coveragePassThreshold');
+  });
+
+  it('accepts valid numeric options in config', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    await writeFile(
+      resolve(TMP_DIR, 'agent-docs.config.yml'),
+      [
+        'url: https://example.com',
+        'options:',
+        '  maxConcurrency: 5',
+        '  requestDelay: 100',
+        '  coveragePassThreshold: 95',
+        '',
+      ].join('\n'),
+    );
+
+    const config = await findConfig(undefined, TMP_DIR);
+    expect(config?.options?.maxConcurrency).toBe(5);
+  });
+
+  it('throws on invalid samplingStrategy in config', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    await writeFile(
+      resolve(TMP_DIR, 'agent-docs.config.yml'),
+      ['url: https://example.com', 'options:', '  samplingStrategy: fastt', ''].join('\n'),
+    );
+
+    await expect(findConfig(undefined, TMP_DIR)).rejects.toThrow('samplingStrategy');
+  });
+
+  it('accepts valid samplingStrategy in config', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    await writeFile(
+      resolve(TMP_DIR, 'agent-docs.config.yml'),
+      ['url: https://example.com', 'options:', '  samplingStrategy: deterministic', ''].join('\n'),
+    );
+
+    const config = await findConfig(undefined, TMP_DIR);
+    expect(config?.options?.samplingStrategy).toBe('deterministic');
+  });
+
+  it('throws when checks is not a string array', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    await writeFile(
+      resolve(TMP_DIR, 'agent-docs.config.yml'),
+      ['url: https://example.com', 'checks:', '  - 42', ''].join('\n'),
+    );
+
+    await expect(findConfig(undefined, TMP_DIR)).rejects.toThrow('checks[0] must be a string');
+  });
+
+  it('throws when skipChecks is not a string array', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    await writeFile(
+      resolve(TMP_DIR, 'agent-docs.config.yml'),
+      ['url: https://example.com', 'skipChecks: true', ''].join('\n'),
+    );
+
+    await expect(findConfig(undefined, TMP_DIR)).rejects.toThrow(
+      'skipChecks" must be an array of strings',
+    );
+  });
+
+  it('validates checks in loadConfig too', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    await writeFile(
+      resolve(TMP_DIR, 'agent-docs.config.yml'),
+      ['url: https://example.com', 'checks: not-an-array', ''].join('\n'),
+    );
+
+    await expect(loadConfig(TMP_DIR)).rejects.toThrow('checks" must be an array of strings');
+  });
+
+  it('throws on invalid thresholds.pass in config', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    await writeFile(
+      resolve(TMP_DIR, 'agent-docs.config.yml'),
+      [
+        'url: https://example.com',
+        'options:',
+        '  thresholds:',
+        '    pass: -1',
+        '    fail: 100000',
+        '',
+      ].join('\n'),
+    );
+
+    await expect(findConfig(undefined, TMP_DIR)).rejects.toThrow('options.thresholds.pass');
+  });
+
+  it('throws on invalid thresholds.fail in config', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    await writeFile(
+      resolve(TMP_DIR, 'agent-docs.config.yml'),
+      [
+        'url: https://example.com',
+        'options:',
+        '  thresholds:',
+        '    pass: 50000',
+        '    fail: 0',
+        '',
+      ].join('\n'),
+    );
+
+    await expect(findConfig(undefined, TMP_DIR)).rejects.toThrow('options.thresholds.fail');
+  });
+
+  it('validates skipChecks in loadConfig', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    await writeFile(
+      resolve(TMP_DIR, 'agent-docs.config.yml'),
+      ['url: https://example.com', 'skipChecks:', '  - 42', ''].join('\n'),
+    );
+
+    await expect(loadConfig(TMP_DIR)).rejects.toThrow('skipChecks[0] must be a string');
   });
 });

--- a/test/unit/helpers/get-page-urls.test.ts
+++ b/test/unit/helpers/get-page-urls.test.ts
@@ -2037,11 +2037,12 @@ describe('discoverAndSamplePages', () => {
   });
 
   it('curated strategy returns configured URLs without discovery', async () => {
+    const curatedPages = ['http://curated.local/page-a', 'http://curated.local/page-b'];
     const ctx = createContext('http://curated.local', {
       requestDelay: 0,
       samplingStrategy: 'curated',
+      curatedPages,
     });
-    ctx._curatedPages = ['http://curated.local/page-a', 'http://curated.local/page-b'];
 
     const result = await discoverAndSamplePages(ctx);
     expect(result.urls).toEqual(['http://curated.local/page-a', 'http://curated.local/page-b']);
@@ -2051,15 +2052,16 @@ describe('discoverAndSamplePages', () => {
   });
 
   it('curated strategy with tagged objects populates urlTags', async () => {
-    const ctx = createContext('http://curated-tags.local', {
-      requestDelay: 0,
-      samplingStrategy: 'curated',
-    });
-    ctx._curatedPages = [
+    const curatedPages = [
       'http://curated-tags.local/page-a',
       { url: 'http://curated-tags.local/page-b', tag: 'api' },
       { url: 'http://curated-tags.local/page-c', tag: 'guides' },
     ];
+    const ctx = createContext('http://curated-tags.local', {
+      requestDelay: 0,
+      samplingStrategy: 'curated',
+      curatedPages,
+    });
 
     const result = await discoverAndSamplePages(ctx);
     expect(result.urls).toHaveLength(3);
@@ -2069,17 +2071,14 @@ describe('discoverAndSamplePages', () => {
     });
   });
 
-  it('curated strategy with empty pages falls back to baseUrl', async () => {
-    const ctx = createContext('http://curated-empty.local', {
-      requestDelay: 0,
-      samplingStrategy: 'curated',
-    });
-    ctx._curatedPages = [];
-
-    const result = await discoverAndSamplePages(ctx);
-    expect(result.urls).toEqual(['http://curated-empty.local']);
-    expect(result.warnings).toHaveLength(1);
-    expect(result.warnings[0]).toContain('no pages defined');
+  it('curated strategy with empty pages throws validation error', () => {
+    expect(() =>
+      createContext('http://curated-empty.local', {
+        requestDelay: 0,
+        samplingStrategy: 'curated',
+        curatedPages: [],
+      }),
+    ).toThrow('Curated sampling requires curatedPages to be non-empty');
   });
 
   it('curated strategy does not apply maxLinksToTest', async () => {
@@ -2088,8 +2087,8 @@ describe('discoverAndSamplePages', () => {
       requestDelay: 0,
       samplingStrategy: 'curated',
       maxLinksToTest: 5,
+      curatedPages: urls,
     });
-    ctx._curatedPages = urls;
 
     const result = await discoverAndSamplePages(ctx);
     expect(result.urls).toHaveLength(100);

--- a/test/unit/runner.test.ts
+++ b/test/unit/runner.test.ts
@@ -73,6 +73,26 @@ describe('createContext URL normalization', () => {
     const ctx = createContext('https://example.com');
     expect(ctx._curatedPages).toBeUndefined();
   });
+
+  it('throws on invalid options', () => {
+    expect(() => createContext('https://example.com', { maxConcurrency: -1 })).toThrow(
+      'Invalid options',
+    );
+  });
+
+  it('normalizes bare domain in canonicalOrigin', () => {
+    const ctx = createContext('https://preview.example.com', {
+      canonicalOrigin: 'example.com',
+    });
+    expect(ctx.options.canonicalOrigin).toBe('https://example.com');
+  });
+
+  it('normalizes bare domain in llmsTxtUrl', () => {
+    const ctx = createContext('https://example.com', {
+      llmsTxtUrl: 'example.com/llms.txt',
+    });
+    expect(ctx.options.llmsTxtUrl).toBe('https://example.com/llms.txt');
+  });
 });
 
 describe('runner', () => {
@@ -466,5 +486,17 @@ describe('runner', () => {
 
     expect(report.discoverySources).toBeDefined();
     expect(report.discoverySources).toContain('llms-txt');
+  });
+
+  it('throws on invalid options', async () => {
+    await expect(runChecks('http://invalid-opts.local', { maxConcurrency: -1 })).rejects.toThrow(
+      'Invalid options',
+    );
+  });
+
+  it('throws on unknown check IDs', async () => {
+    await expect(
+      runChecks('http://invalid-opts.local', { checkIds: ['nonexistent-check'] }),
+    ).rejects.toThrow('Unknown check ID');
   });
 });

--- a/test/unit/validation.test.ts
+++ b/test/unit/validation.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect } from 'vitest';
+import { validateRunnerOptions } from '../../src/validation.js';
+import type { RunnerOptions } from '../../src/types.js';
+
+// Ensure all checks are registered for check ID validation
+import '../../src/checks/index.js';
+
+describe('validateRunnerOptions', () => {
+  it('returns valid for empty options', () => {
+    const result = validateRunnerOptions({});
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('returns valid for well-formed options', () => {
+    const result = validateRunnerOptions({
+      maxConcurrency: 5,
+      requestDelay: 100,
+      maxLinksToTest: 25,
+      samplingStrategy: 'random',
+      thresholds: { pass: 50_000, fail: 100_000 },
+      coveragePassThreshold: 95,
+      coverageWarnThreshold: 80,
+      parityPassThreshold: 5,
+      parityWarnThreshold: 20,
+    });
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('collects multiple errors in a single call', () => {
+    const result = validateRunnerOptions({
+      maxConcurrency: -1,
+      requestDelay: -1,
+      samplingStrategy: 'invalid' as RunnerOptions['samplingStrategy'],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThanOrEqual(3);
+  });
+
+  describe('NaN checking', () => {
+    const nanFields: [string, Partial<RunnerOptions>][] = [
+      ['maxConcurrency', { maxConcurrency: NaN }],
+      ['requestDelay', { requestDelay: NaN }],
+      ['requestTimeout', { requestTimeout: NaN }],
+      ['maxLinksToTest', { maxLinksToTest: NaN }],
+      ['coveragePassThreshold', { coveragePassThreshold: NaN }],
+      ['coverageWarnThreshold', { coverageWarnThreshold: NaN }],
+      ['parityPassThreshold', { parityPassThreshold: NaN }],
+      ['parityWarnThreshold', { parityWarnThreshold: NaN }],
+    ];
+
+    for (const [field, opts] of nanFields) {
+      it(`rejects NaN ${field}`, () => {
+        const result = validateRunnerOptions(opts);
+        expect(result.valid).toBe(false);
+        expect(result.errors.some((e) => e.field === field)).toBe(true);
+      });
+    }
+
+    it('rejects NaN thresholds.pass', () => {
+      const result = validateRunnerOptions({ thresholds: { pass: NaN, fail: 100_000 } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.field === 'thresholds.pass')).toBe(true);
+    });
+
+    it('rejects NaN thresholds.fail', () => {
+      const result = validateRunnerOptions({ thresholds: { pass: 50_000, fail: NaN } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.field === 'thresholds.fail')).toBe(true);
+    });
+  });
+
+  describe('numeric range: maxConcurrency', () => {
+    it('rejects 0', () => {
+      const result = validateRunnerOptions({ maxConcurrency: 0 });
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].field).toBe('maxConcurrency');
+    });
+
+    it('rejects negative values', () => {
+      const result = validateRunnerOptions({ maxConcurrency: -5 });
+      expect(result.valid).toBe(false);
+    });
+
+    it('accepts 1', () => {
+      expect(validateRunnerOptions({ maxConcurrency: 1 }).valid).toBe(true);
+    });
+
+    it('accepts 100', () => {
+      expect(validateRunnerOptions({ maxConcurrency: 100 }).valid).toBe(true);
+    });
+
+    it('rejects 101', () => {
+      const result = validateRunnerOptions({ maxConcurrency: 101 });
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toContain('between 1 and 100');
+    });
+
+    it('rejects non-integer', () => {
+      const result = validateRunnerOptions({ maxConcurrency: 3.5 });
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toContain('integer');
+    });
+  });
+
+  describe('numeric range: requestDelay', () => {
+    it('accepts 0', () => {
+      expect(validateRunnerOptions({ requestDelay: 0 }).valid).toBe(true);
+    });
+
+    it('rejects negative values', () => {
+      const result = validateRunnerOptions({ requestDelay: -1 });
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].field).toBe('requestDelay');
+    });
+  });
+
+  describe('numeric range: maxLinksToTest', () => {
+    it('rejects 0', () => {
+      const result = validateRunnerOptions({ maxLinksToTest: 0 });
+      expect(result.valid).toBe(false);
+    });
+
+    it('accepts 1', () => {
+      expect(validateRunnerOptions({ maxLinksToTest: 1 }).valid).toBe(true);
+    });
+  });
+
+  describe('numeric range: size thresholds', () => {
+    it('rejects thresholds.pass < 1', () => {
+      const result = validateRunnerOptions({ thresholds: { pass: 0, fail: 100_000 } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.field === 'thresholds.pass')).toBe(true);
+    });
+
+    it('rejects thresholds.fail < 1', () => {
+      const result = validateRunnerOptions({ thresholds: { pass: 50_000, fail: 0 } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.field === 'thresholds.fail')).toBe(true);
+    });
+  });
+
+  describe('numeric range: coverage thresholds', () => {
+    it('rejects coveragePassThreshold > 100', () => {
+      const result = validateRunnerOptions({ coveragePassThreshold: 101 });
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects coveragePassThreshold < 0', () => {
+      const result = validateRunnerOptions({ coveragePassThreshold: -1 });
+      expect(result.valid).toBe(false);
+    });
+
+    it('accepts boundary values 0 and 100', () => {
+      expect(validateRunnerOptions({ coveragePassThreshold: 0 }).valid).toBe(true);
+      expect(validateRunnerOptions({ coveragePassThreshold: 100 }).valid).toBe(true);
+    });
+  });
+
+  describe('numeric range: parity thresholds', () => {
+    it('rejects parityPassThreshold > 100', () => {
+      const result = validateRunnerOptions({ parityPassThreshold: 101 });
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects parityWarnThreshold < 0', () => {
+      const result = validateRunnerOptions({ parityWarnThreshold: -1 });
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('threshold ordering: size', () => {
+    it('errors when pass > fail', () => {
+      const result = validateRunnerOptions({ thresholds: { pass: 200_000, fail: 100_000 } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.field === 'thresholds')).toBe(true);
+    });
+
+    it('accepts pass === fail', () => {
+      expect(validateRunnerOptions({ thresholds: { pass: 50_000, fail: 50_000 } }).valid).toBe(
+        true,
+      );
+    });
+
+    it('accepts pass < fail', () => {
+      expect(validateRunnerOptions({ thresholds: { pass: 50_000, fail: 100_000 } }).valid).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('threshold ordering: coverage', () => {
+    it('errors when pass < warn', () => {
+      const result = validateRunnerOptions({
+        coveragePassThreshold: 50,
+        coverageWarnThreshold: 80,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.field === 'coveragePassThreshold')).toBe(true);
+      expect(result.errors[0].message).toContain('greater than or equal to');
+    });
+
+    it('accepts pass > warn', () => {
+      expect(
+        validateRunnerOptions({ coveragePassThreshold: 95, coverageWarnThreshold: 80 }).valid,
+      ).toBe(true);
+    });
+
+    it('accepts pass === warn', () => {
+      expect(
+        validateRunnerOptions({ coveragePassThreshold: 80, coverageWarnThreshold: 80 }).valid,
+      ).toBe(true);
+    });
+
+    it('skips ordering check when only pass provided', () => {
+      expect(validateRunnerOptions({ coveragePassThreshold: 50 }).valid).toBe(true);
+    });
+
+    it('skips ordering check when only warn provided', () => {
+      expect(validateRunnerOptions({ coverageWarnThreshold: 80 }).valid).toBe(true);
+    });
+  });
+
+  describe('threshold ordering: parity', () => {
+    it('errors when pass > warn', () => {
+      const result = validateRunnerOptions({
+        parityPassThreshold: 30,
+        parityWarnThreshold: 10,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.field === 'parityPassThreshold')).toBe(true);
+      expect(result.errors[0].message).toContain('less than or equal to');
+    });
+
+    it('accepts pass < warn', () => {
+      expect(validateRunnerOptions({ parityPassThreshold: 5, parityWarnThreshold: 20 }).valid).toBe(
+        true,
+      );
+    });
+
+    it('accepts pass === warn', () => {
+      expect(
+        validateRunnerOptions({ parityPassThreshold: 10, parityWarnThreshold: 10 }).valid,
+      ).toBe(true);
+    });
+
+    it('skips ordering check when only pass provided', () => {
+      expect(validateRunnerOptions({ parityPassThreshold: 30 }).valid).toBe(true);
+    });
+  });
+
+  describe('enum: samplingStrategy', () => {
+    it('rejects invalid strategy', () => {
+      const result = validateRunnerOptions({
+        samplingStrategy: 'invalid' as RunnerOptions['samplingStrategy'],
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].field).toBe('samplingStrategy');
+      expect(result.errors[0].message).toContain('random');
+    });
+
+    for (const strategy of ['random', 'deterministic', 'curated', 'none'] as const) {
+      it(`accepts "${strategy}"`, () => {
+        const opts: Partial<RunnerOptions> =
+          strategy === 'curated'
+            ? { samplingStrategy: strategy, curatedPages: ['https://example.com/a'] }
+            : { samplingStrategy: strategy };
+        expect(validateRunnerOptions(opts).valid).toBe(true);
+      });
+    }
+  });
+
+  describe('constraint: curated requires pages', () => {
+    it('errors for curated with no curatedPages', () => {
+      const result = validateRunnerOptions({ samplingStrategy: 'curated' });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.message.includes('curatedPages'))).toBe(true);
+    });
+
+    it('errors for curated with empty curatedPages', () => {
+      const result = validateRunnerOptions({ samplingStrategy: 'curated', curatedPages: [] });
+      expect(result.valid).toBe(false);
+    });
+
+    it('accepts curated with curatedPages', () => {
+      const result = validateRunnerOptions({
+        samplingStrategy: 'curated',
+        curatedPages: ['https://example.com/a'],
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('URL validation', () => {
+    it('errors for invalid canonicalOrigin', () => {
+      const result = validateRunnerOptions({ canonicalOrigin: 'not a url' });
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].field).toBe('canonicalOrigin');
+    });
+
+    it('accepts valid canonicalOrigin', () => {
+      expect(validateRunnerOptions({ canonicalOrigin: 'https://example.com' }).valid).toBe(true);
+    });
+
+    it('errors for invalid llmsTxtUrl', () => {
+      const result = validateRunnerOptions({ llmsTxtUrl: 'not a url' });
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].field).toBe('llmsTxtUrl');
+    });
+
+    it('accepts valid llmsTxtUrl', () => {
+      expect(validateRunnerOptions({ llmsTxtUrl: 'https://example.com/llms.txt' }).valid).toBe(
+        true,
+      );
+    });
+
+    it('skips validation when undefined', () => {
+      expect(validateRunnerOptions({ canonicalOrigin: undefined }).valid).toBe(true);
+    });
+  });
+
+  describe('check IDs', () => {
+    it('errors for unknown checkIds', () => {
+      const result = validateRunnerOptions({ checkIds: ['llms-txt-exists', 'nonexistent-check'] });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].field).toBe('checkIds');
+      expect(result.errors[0].message).toContain('nonexistent-check');
+    });
+
+    it('errors for unknown skipCheckIds', () => {
+      const result = validateRunnerOptions({ skipCheckIds: ['nonexistent-check'] });
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].field).toBe('skipCheckIds');
+    });
+
+    it('accepts valid checkIds', () => {
+      const result = validateRunnerOptions({ checkIds: ['llms-txt-exists'] });
+      expect(result.valid).toBe(true);
+    });
+
+    it('accepts empty checkIds', () => {
+      const result = validateRunnerOptions({ checkIds: [] });
+      expect(result.valid).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Create `src/validation.ts` with `validateRunnerOptions()` that validates all runner options (numeric ranges, threshold ordering, enum values, curated+pages constraint, URL syntax, and check ID existence) and returns structured `{ valid, errors[], warnings[] }`
- Integrate validation into `createContext()` so both `runChecks()` and direct `createContext()` callers get input validation
- Replace scattered inline validation in the CLI with a single `validateRunnerOptions()` call before `runChecks()`
- Remove threshold validation from individual checks (`llms-txt-coverage` and `markdown-content-parity`) since it's now handled before checks run
- Add numeric option and sampling strategy validation to config file loading, and extract duplicated config validation into shared `validateConfig()` helper
- Normalize `canonicalOrigin` and `llmsTxtUrl` in `createContext()` to match existing `baseUrl` normalization (prepend `https://` if no scheme)
- Export `validateRunnerOptions`, `VALID_SAMPLING_STRATEGIES`, and validation types from the public API for library consumers
- Document new exports and throwing behavior in programmatic API docs

## Test plan

- [x] `npx vitest run` — 1211 tests across 53 files pass
- [x] New `test/unit/validation.test.ts` — 59 tests covering all validation rules (NaN, ranges, threshold ordering, enums, constraints, URLs, check IDs)
- [x] CLI edge case tests — config load errors, `--skip-checks` parsing, `--canonical-origin` same-origin warning and invalid URL fallback, `--coverage-exclusions`, `--parity-exclusions`, validation warnings output
- [x] Config tests — invalid numeric options, non-numeric values, out-of-range thresholds, invalid sampling strategy, non-string checks/skipChecks arrays
- [x] Runner tests — `createContext()` throws on invalid options, normalizes bare domains in URL options
- [x] Coverage: `check.ts` 100%, `config.ts` 100%, `validation.ts` 98.5%, `runner.ts` 98.6% (remaining gaps are JS-consumer type guards and internal branches)