### PR TITLE
Fix rendering strategy diagnostics

### DIFF
--- a/SCORING.md
+++ b/SCORING.md
@@ -59,7 +59,7 @@ Whether agents can process your pages without losing content.
 
 | Check                                                                            | Weight        | What it measures                                                                                      |
 | -------------------------------------------------------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------- |
-| [rendering-strategy](https://agentdocsspec.com/spec/#rendering-strategy)         | Critical (10) | Whether pages use server-side rendering. Client-side (SPA) pages deliver empty shells to agents.      |
+| [rendering-strategy](https://agentdocsspec.com/spec/#rendering-strategy)         | Critical (10) | Whether pages are fully server-rendered, server-rendered but sparse, or empty SPA shells.             |
 | [page-size-markdown](https://agentdocsspec.com/spec/#page-size-markdown)         | High (7)      | Whether markdown pages fit within agent processing limits (~100K characters).                         |
 | [page-size-html](https://agentdocsspec.com/spec/#page-size-html)                 | High (7)      | Whether HTML pages, once converted to text, fit within agent processing limits.                       |
 | [content-start-position](https://agentdocsspec.com/spec/#content-start-position) | Medium (4)    | Whether documentation content starts near the top of the page, or is buried under boilerplate CSS/JS. |
@@ -160,16 +160,18 @@ Some problems are severe enough that no amount of other good behavior should com
 
 ### Critical check caps
 
-| Condition                                          | Cap    | Why                                                                            |
-| -------------------------------------------------- | ------ | ------------------------------------------------------------------------------ |
-| `llms-txt-exists` fails                            | 59 (D) | Agents lose primary navigation but may still use HTML/markdown paths directly. |
-| `rendering-strategy`: 75%+ of pages are SPA shells | 39 (F) | Most content is invisible to agents.                                           |
-| `rendering-strategy`: 50%+ of pages are SPA shells | 59 (D) | Significant content is invisible to agents.                                    |
-| `auth-gate-detection`: 75%+ of pages require auth  | 39 (F) | Most documentation is inaccessible.                                            |
-| `auth-gate-detection`: 50%+ of pages require auth  | 59 (D) | Significant documentation is inaccessible.                                     |
-| `no-viable-path` diagnostic fires (see below)      | 39 (F) | Agents have no effective way to access content at all.                         |
+| Condition                                         | Cap    | Why                                                                            |
+| ------------------------------------------------- | ------ | ------------------------------------------------------------------------------ |
+| `llms-txt-exists` fails                           | 59 (D) | Agents lose primary navigation but may still use HTML/markdown paths directly. |
+| `rendering-strategy`: proportion ≤ 0.25           | 39 (F) | Most content is invisible to agents.                                           |
+| `rendering-strategy`: proportion ≤ 0.50           | 59 (D) | Significant content is invisible to agents.                                    |
+| `auth-gate-detection`: 75%+ of pages require auth | 39 (F) | Most documentation is inaccessible.                                            |
+| `auth-gate-detection`: 50%+ of pages require auth | 59 (D) | Significant documentation is inaccessible.                                     |
+| `no-viable-path` diagnostic fires (see below)     | 39 (F) | Agents have no effective way to access content at all.                         |
 
 When multiple caps apply, the lowest one wins.
+
+The `rendering-strategy` proportion is `(serverRendered + sparseContent × 0.5) / total`: empty SPA shells count fully against the proportion, while server-rendered-but-sparse pages count at half weight.
 
 The `rendering-strategy` and `auth-gate-detection` caps do not apply when the check has `scoreDisplayMode: "notApplicable"` (insufficient data). If we don't trust the data enough to include it in the score, we don't trust it enough to cap the score either.
 
@@ -292,7 +294,7 @@ If multiple conditions are met, the highest coefficient applies.
 
 **Affects**: `page-size-html`, `content-start-position`, `tabbed-content-serialization`, `section-header-quality`
 
-If pages are SPA shells, measuring HTML quality is meaningless. This coefficient equals the `rendering-strategy` check's proportion: if 90% of pages render correctly, these checks count for 90% of their weight.
+If pages are SPA shells, measuring HTML quality is meaningless; if pages are sparse, HTML quality counts for less because agents have less content to work with. This coefficient equals the same weighted proportion that drives the score caps above: `(serverRendered + sparseContent × 0.5) / total`. Fully server-rendered pages count for full weight, sparse pages count for half, and SPA shells count for nothing.
 
 ### Index truncation coefficient
 

--- a/docs/agent-score-calculation.md
+++ b/docs/agent-score-calculation.md
@@ -95,25 +95,25 @@ Checks that test multiple pages use proportional scoring. If `page-size-html` te
 
 These checks sample pages from your site and score based on the pass rate across those pages:
 
-| Check                          | What's measured per page                                            |
-| ------------------------------ | ------------------------------------------------------------------- |
-| `rendering-strategy`           | Whether the page is server-rendered or an SPA shell                 |
-| `page-size-html`               | Whether the HTML-to-text conversion fits within size limits         |
-| `page-size-markdown`           | Whether the markdown version fits within size limits                |
-| `content-start-position`       | How far into the response actual content begins                     |
-| `content-negotiation`          | Whether the server returns markdown for this page                   |
-| `markdown-url-support`         | Whether the `.md` URL variant returns markdown                      |
-| `http-status-codes`            | Whether a fabricated bad URL returns a proper 404                   |
-| `redirect-behavior`            | Whether redirects use standard HTTP methods                         |
-| `auth-gate-detection`          | Whether the page is publicly accessible                             |
-| `llms-txt-directive-html`      | Whether the HTML page includes a directive pointing to llms.txt     |
-| `llms-txt-directive-md`        | Whether the markdown page includes a directive pointing to llms.txt |
-| `tabbed-content-serialization` | Whether tabbed content creates oversized output                     |
-| `section-header-quality`       | Whether tab section headers include variant context                 |
-| `markdown-code-fence-validity` | Whether code fences are properly closed                             |
-| `markdown-content-parity`      | Whether markdown and HTML versions match                            |
-| `cache-header-hygiene`         | Whether cache headers allow timely updates                          |
-| `auth-alternative-access`      | Whether auth-gated pages have alternative access paths              |
+| Check                          | What's measured per page                                                                     |
+| ------------------------------ | -------------------------------------------------------------------------------------------- |
+| `rendering-strategy`           | Whether the page is fully server-rendered, server-rendered but sparse, or an empty SPA shell |
+| `page-size-html`               | Whether the HTML-to-text conversion fits within size limits                                  |
+| `page-size-markdown`           | Whether the markdown version fits within size limits                                         |
+| `content-start-position`       | How far into the response actual content begins                                              |
+| `content-negotiation`          | Whether the server returns markdown for this page                                            |
+| `markdown-url-support`         | Whether the `.md` URL variant returns markdown                                               |
+| `http-status-codes`            | Whether a fabricated bad URL returns a proper 404                                            |
+| `redirect-behavior`            | Whether redirects use standard HTTP methods                                                  |
+| `auth-gate-detection`          | Whether the page is publicly accessible                                                      |
+| `llms-txt-directive-html`      | Whether the HTML page includes a directive pointing to llms.txt                              |
+| `llms-txt-directive-md`        | Whether the markdown page includes a directive pointing to llms.txt                          |
+| `tabbed-content-serialization` | Whether tabbed content creates oversized output                                              |
+| `section-header-quality`       | Whether tab section headers include variant context                                          |
+| `markdown-code-fence-validity` | Whether code fences are properly closed                                                      |
+| `markdown-content-parity`      | Whether markdown and HTML versions match                                                     |
+| `cache-header-hygiene`         | Whether cache headers allow timely updates                                                   |
+| `auth-alternative-access`      | Whether auth-gated pages have alternative access paths                                       |
 
 ### Single-resource checks (all-or-nothing)
 
@@ -150,13 +150,15 @@ Some problems are severe enough that no amount of other passing checks should co
 | Condition                                                                             | Cap    | Why                                                    |
 | ------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------ |
 | `llms-txt-exists` fails                                                               | 59 (D) | Agents lose their primary navigation mechanism.        |
-| `rendering-strategy`: 75%+ SPA shells                                                 | 39 (F) | Most content is invisible to agents.                   |
-| `rendering-strategy`: 50%+ SPA shells                                                 | 59 (D) | Significant content is invisible.                      |
+| `rendering-strategy`: proportion ≤ 0.25                                               | 39 (F) | Most content is invisible to agents.                   |
+| `rendering-strategy`: proportion ≤ 0.50                                               | 59 (D) | Significant content is invisible.                      |
 | `auth-gate-detection`: 75%+ pages gated                                               | 39 (F) | Most documentation is inaccessible.                    |
 | `auth-gate-detection`: 50%+ pages gated                                               | 59 (D) | Significant documentation is inaccessible.             |
 | [No viable path](/interaction-diagnostics#no-viable-path-to-content) diagnostic fires | 39 (F) | Agents have no effective way to access content at all. |
 
 When multiple caps apply, the lowest one wins.
+
+The `rendering-strategy` proportion is `(serverRendered + sparseContent × 0.5) / total`: empty SPA shells count fully against the proportion, while server-rendered-but-sparse pages count at half weight. A site that's entirely SPA shells has proportion 0 (caps at F). A site that's half shells and half full content has proportion 0.5 (caps at D). A site that's entirely sparse-but-rendered has proportion 0.5 (also caps at D, on the assumption that sparse pages are half-broken on average); after the heuristic fix, legitimately short pages no longer count as sparse, so this scenario is much rarer.
 
 The `rendering-strategy` and `auth-gate-detection` caps do not apply when the check is marked as not applicable due to [insufficient data](#insufficient-data). If there isn't enough data to include the check in the score, there isn't enough data to cap the score based on it either.
 
@@ -197,7 +199,7 @@ Note that `markdown-url-support` is intentionally excluded from this coefficient
 
 **Affects**: `page-size-html`, `content-start-position`, `tabbed-content-serialization`, `section-header-quality`
 
-If pages are SPA shells, measuring HTML quality is meaningless. This coefficient equals the `rendering-strategy` check's pass proportion: if 90% of pages render correctly, these checks count for 90% of their weight.
+If pages are SPA shells, measuring HTML quality is meaningless; if pages are sparse, HTML quality counts for less because agents have less content to work with. This coefficient equals the same proportion that drives the score caps above: `(serverRendered + sparseContent × 0.5) / total`. Fully server-rendered pages count for full weight, sparse pages count for half, and SPA shells count for nothing.
 
 ### Index truncation coefficient
 

--- a/docs/checks/page-size.md
+++ b/docs/checks/page-size.md
@@ -37,12 +37,12 @@ When the check warns, the [`sparse-content-html` diagnostic](/interaction-diagno
 
 ### Score impact
 
-This is a Critical check with two score caps:
+This is a Critical check with two score caps based on a weighted proportion: `(serverRendered + sparseContent × 0.5) / total`. Empty SPA shells count fully against the proportion; sparse pages count at half weight.
 
-- At 50%+ SPA shells, the score is [capped at D (59)](/agent-score-calculation#score-caps).
-- At 75%+ SPA shells, the score is [capped at F (39)](/agent-score-calculation#score-caps).
+- When the proportion is at most 0.50, the score is [capped at D (59)](/agent-score-calculation#score-caps).
+- When the proportion is at most 0.25, the score is [capped at F (39)](/agent-score-calculation#score-caps).
 
-The `rendering-strategy` pass rate also drives the [HTML path coefficient](/agent-score-calculation#html-path-coefficient). If 90% of pages render correctly, HTML quality checks (`page-size-html`, `content-start-position`, `tabbed-content-serialization`, `section-header-quality`) count for 90% of their weight.
+The same proportion drives the [HTML path coefficient](/agent-score-calculation#html-path-coefficient). If 90% of pages render correctly with no sparse pages, HTML quality checks (`page-size-html`, `content-start-position`, `tabbed-content-serialization`, `section-header-quality`) count for 90% of their weight.
 
 ---
 

--- a/docs/checks/page-size.md
+++ b/docs/checks/page-size.md
@@ -21,15 +21,17 @@ The rendering strategy is a property of the framework and its configuration, not
 
 ### Results
 
-| Result | Condition                                                                                                 |
-| ------ | --------------------------------------------------------------------------------------------------------- |
-| Pass   | Pages contain substantive server-rendered content (headings, prose, code blocks)                          |
-| Warn   | Some content present but sparse (possible partial hydration or lazy loading)                              |
-| Fail   | SPA shell detected (framework markers like `id="__next"`, minimal visible text, no page-specific content) |
+| Result | Condition                                                                                                                      |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| Pass   | Pages contain substantive server-rendered content (headings, prose, code blocks)                                               |
+| Warn   | Pages render server-side but have unusually short body content (legitimately short pages, or partial hydration / lazy loading) |
+| Fail   | SPA shell detected (framework markers like `id="__next"`, minimal visible text, no page-specific content)                      |
+
+When the check warns, the [`sparse-content-html` diagnostic](/interaction-diagnostics#sparse-content-on-the-html-path) fires if more than 25% of sampled pages are sparse. When the check fails, the [`spa-shell-html-invalid` diagnostic](/interaction-diagnostics#spa-shells-invalidate-html-path) fires if more than 25% of sampled pages are actual shells.
 
 ### How to fix
 
-**If this check warns**, verify that key content is present in the server-rendered HTML response. Some pages may use component-level client rendering or lazy loading for specific sections.
+**If this check warns**, spot-check the affected pages by fetching them with `curl` or another HTTP client that doesn't run JavaScript. If the pages contain their full intended content, no action is needed; some pages are legitimately brief. If content is missing from the server response, the page may use component-level client rendering or lazy loading for specific sections.
 
 **If this check fails**, enable server-side rendering or static site generation in your docs platform. This is typically a configuration change, not a code rewrite.
 

--- a/docs/improve-your-score.md
+++ b/docs/improve-your-score.md
@@ -76,7 +76,7 @@ If `rendering-strategy` fails, your site is delivering empty JavaScript shells t
 
 If `rendering-strategy` warns, your pages render server-side but have unusually short body content. Spot-check a few of them with `curl` to confirm the full content is in the HTML response. If the pages are legitimately short, no action is needed. If content is missing, your renderer may be hydrating sections client-side; emitting them server-side will fix it.
 
-At 50%+ SPA shells, the score is [capped at D](/agent-score-calculation#score-caps) regardless of everything else.
+When SPA shells (and sparse pages, weighted at half) exceed half the sampled pages, the score is [capped at D](/agent-score-calculation#score-caps) regardless of everything else; when they exceed three quarters, it's capped at F.
 
 **Remove or work around authentication gates**
 

--- a/docs/improve-your-score.md
+++ b/docs/improve-your-score.md
@@ -72,7 +72,9 @@ This also unblocks five dependent checks (`llms-txt-valid`, `llms-txt-size`, `ll
 
 **Enable server-side rendering**
 
-If `rendering-strategy` warns or fails, your site is delivering empty JavaScript shells to agents. Enable SSR or static site generation in your docs platform. This is typically a configuration flag, not a code change.
+If `rendering-strategy` fails, your site is delivering empty JavaScript shells to agents. Enable SSR or static site generation in your docs platform. This is typically a configuration flag, not a code change.
+
+If `rendering-strategy` warns, your pages render server-side but have unusually short body content. Spot-check a few of them with `curl` to confirm the full content is in the HTML response. If the pages are legitimately short, no action is needed. If content is missing, your renderer may be hydrating sections client-side; emitting them server-side will fix it.
 
 At 50%+ SPA shells, the score is [capped at D](/agent-score-calculation#score-caps) regardless of everything else.
 

--- a/docs/interaction-diagnostics.md
+++ b/docs/interaction-diagnostics.md
@@ -36,13 +36,23 @@ These diagnostics appear in the "Interaction Diagnostics" section of the `--form
 
 ## SPA shells invalidate HTML path
 
-**Triggers when** more than 25% of sampled pages use client-side rendering (the `rendering-strategy` check warns or fails).
+**Triggers when** more than 25% of sampled pages are detected as actual SPA shells: pages where the HTML response contains a framework root element (such as `id="__next"` or `id="root"`) but no documentation content.
 
 **What it means**: When humans visit the page in a browser, JavaScript loads the content. Agents don't visit a page in a browser, so they never see the content, only the shell. Page size and content structure scores for the HTML path are discounted because they're partially measuring shells, not actual content.
 
 **What to do**: Enable server-side rendering or static generation for documentation pages. If only specific page templates use client-side content loading, target those templates. The [rendering-strategy check](/checks/page-size#rendering-strategy) explains how AFDocs detects SPA shells.
 
 **Score impact**: The HTML path coefficient scales `page-size-html`, `content-start-position`, `tabbed-content-serialization`, and `section-header-quality` in proportion to the fraction of pages that render correctly. If 60% of pages are SPA shells, these checks count for 40% of their weight. At 50%+ SPA shells, the overall score is also [capped at D or F](/agent-score-calculation#score-caps).
+
+## Sparse content on the HTML path
+
+**Triggers when** more than 25% of sampled pages render server-side but have unusually short body content, AND the SPA-shells diagnostic is not also firing. (When both conditions hold, the SPA-shells diagnostic takes precedence to avoid double-reporting; its resolution covers both.)
+
+**What it means**: The HTML response contains real content (headings and visible text) but less than the threshold for a typical documentation page. This is often legitimate (short reference pages, integration one-liners, glossary entries) and not actually a problem. It can also indicate a renderer that hydrates paragraphs, lists, or code blocks client-side rather than emitting them in the initial HTML, in which case agents would miss the hydrated content.
+
+**What to do**: Spot-check a few of the affected pages by fetching them with `curl` (or any HTTP client that doesn't run JavaScript) and confirm the full content is present. If the pages are intentionally brief, no action is needed. If content is missing from the server response, investigate your renderer's server-side output for paragraphs, lists, and code blocks.
+
+**Score impact**: The HTML path coefficient is discounted for sparse pages at half the rate of full SPA shells. Sparse pages do not contribute to the score cap.
 
 ## No viable path to content
 

--- a/scoring-reference.md
+++ b/scoring-reference.md
@@ -248,9 +248,9 @@ For each critical check:
     apply cap (total failure)
   if multi-page AND scoreDisplayMode == 'notApplicable':
     skip (insufficient data to justify a cap)
-  if multi-page AND proportion <= 0.25 (75%+ of pages fail):
+  if multi-page AND proportion <= 0.25:
     cap overall score at 39 (F)
-  if multi-page AND proportion <= 0.50 (50%+ of pages fail):
+  if multi-page AND proportion <= 0.50:
     cap overall score at 59 (D)
 ```
 
@@ -266,11 +266,13 @@ discoverable markdown. It's a significant gap, not a total blocker.
 
 For multi-page critical checks (`rendering-strategy`, `auth-gate-detection`):
 
-| Proportion | Meaning                    | Cap                                     |
-| ---------- | -------------------------- | --------------------------------------- |
-| <= 0.25    | 75%+ of pages affected     | Cap at 39 (F)                           |
-| <= 0.50    | 50%+ of pages affected     | Cap at 59 (D)                           |
-| > 0.50     | Minority of pages affected | No cap; proportional scoring handles it |
+| Proportion | Meaning                                | Cap                                     |
+| ---------- | -------------------------------------- | --------------------------------------- |
+| <= 0.25    | Most pages affected                    | Cap at 39 (F)                           |
+| <= 0.50    | Significant fraction of pages affected | Cap at 59 (D)                           |
+| > 0.50     | Minority of pages affected             | No cap; proportional scoring handles it |
+
+For `rendering-strategy`, the proportion is `(serverRendered + sparseContent × 0.5) / total`: empty SPA shells count fully against the proportion, while server-rendered-but-sparse pages count at half weight. For `auth-gate-detection`, the proportion is the straight pass rate.
 
 ### Diagnostic-Driven Cap: `no-viable-path`
 

--- a/scoring-reference.md
+++ b/scoring-reference.md
@@ -485,18 +485,45 @@ in dependency order: `markdown-undiscoverable` and
 #### `spa-shell-html-invalid`
 
 - **Severity**: info
-- **Triggers when**: `rendering-strategy` fails or warns (proportionally:
-  when >25% of sampled pages are SPA shells).
-- **Message**: {n} of {total} sampled pages use client-side rendering. Agents
-  receive an empty shell for these pages instead of documentation content.
-  Page size and content structure scores for the HTML path are discounted
-  because they are partially measuring shells rather than content.
+- **Triggers when**: `rendering-strategy` does not pass AND >25% of sampled
+  pages are detected as actual SPA shells (framework root element present,
+  no documentation content). Sparse-but-rendered pages do not contribute
+  to this trigger; they are reported separately by `sparse-content-html`.
+- **Message**: {n} of {total} sampled pages are client-side-rendered shells:
+  the HTML response contains a framework root element but no documentation
+  content. Agents using HTTP fetches receive empty pages. Page size and
+  content structure scores for the HTML path are discounted because they
+  are partially measuring shells rather than content.
   {If markdown-url-support passes: "Your markdown path still works for agents
   that can discover it."} {If not: "Agents currently have no alternative path
   to content on affected pages."}
 - **Resolution**: Enable server-side rendering or static generation for
   affected page types. If only specific page templates use client-side content
   loading, target those templates rather than rebuilding the entire site.
+
+#### `sparse-content-html`
+
+- **Severity**: info
+- **Triggers when**: `rendering-strategy` does not pass AND >25% of sampled
+  pages are sparse (server-rendered but with unusually short body content)
+  AND `spa-shell-html-invalid` did not fire. The shell diagnostic is the
+  bigger problem on mixed sites; this diagnostic is suppressed in that case
+  to avoid double-reporting.
+- **Message**: {n} of {total} sampled pages render server-side but have
+  unusually short body content. The HTML response contains real content
+  (headings and visible text), just less than the threshold for a full
+  documentation page. This is often legitimate (short reference pages,
+  integration one-liners, glossary entries), but can also indicate a
+  renderer that is not emitting full content. Page size scoring on the HTML
+  path is discounted for these pages.
+  {If markdown-url-support passes: "Your markdown path still works for agents
+  that can discover it."} {If not: "Agents have no alternative path on
+  affected pages, so any missing content is invisible."}
+- **Resolution**: Verify the affected pages render their full content
+  server-side. If the pages are intentionally brief, no action is needed;
+  this is informational. If content is missing, check whether your renderer
+  is emitting paragraphs, lists, and code blocks server-side rather than
+  hydrating them client-side.
 
 #### `no-viable-path`
 

--- a/src/helpers/detect-rendering.ts
+++ b/src/helpers/detect-rendering.ts
@@ -99,19 +99,37 @@ export function analyzeRendering(html: string): RenderingAnalysis {
     hasMainContent = mainParagraphs >= 2 || mainCode >= 1;
   }
 
-  // Determine if the page has real content
-  // A page has content if it has enough content signals, regardless of text ratio.
-  // The visibleTextLength clause covers div-soup SSR (Next.js custom renderers,
-  // Archbee, etc.) where prose is wrapped in <div>/<span> rather than <p>/<main>.
-  // Threshold is applied after chrome stripping above, so nav/sidebar text on an
-  // otherwise-empty SPA shell does not satisfy it.
+  // Determine if the page has real content.
+  //
+  // The disjunction below combines several independent positive signals; any
+  // one is enough. All text-length thresholds apply after chrome stripping
+  // (nav/header/footer/aside removed above), so menu and breadcrumb text on
+  // an otherwise-empty SPA shell does not satisfy them.
+  //
+  // - visibleTextLength >= 1500: long page, possibly without semantic markup
+  //   (rare wall-of-text case where no headings parse).
+  // - contentHeadings >= 1 && visibleTextLength >= 500: short doc pages that
+  //   have a heading and a meaningful body. Catches div-soup renderers
+  //   (Archbee, custom Next.js setups) on legitimately short pages —
+  //   integration explainers, glossary entries, single-feature notes — that
+  //   used to be misclassified as sparse because their <500-char body sat
+  //   below the 1500 wall-of-text threshold. True SPA shells fail this
+  //   clause: their post-chrome-strip body is effectively empty (~0 chars),
+  //   nowhere near 500.
+  // - contentHeadings >= 3: multi-section pages (typical reference docs).
+  // - contentParagraphs >= 5: well-structured prose with semantic <p> tags.
+  // - hasMainContent && contentHeadings >= 1: pages with a populated <main>
+  //   region and at least one heading — the canonical doc-page shape.
+  // - codeBlocks >= 3: API references and code-heavy pages.
+  // - !hasSpaMarkers: traditional server-rendered HTML; not a shell candidate.
   const hasContent =
     visibleTextLength >= 1500 ||
+    (contentHeadings >= 1 && visibleTextLength >= 500) ||
     contentHeadings >= 3 ||
     contentParagraphs >= 5 ||
     (hasMainContent && contentHeadings >= 1) ||
     codeBlocks >= 3 ||
-    !hasSpaMarkers; // No SPA markers = traditional server-rendered, assume content
+    !hasSpaMarkers;
 
   return {
     hasContent,

--- a/src/scoring/diagnostics.ts
+++ b/src/scoring/diagnostics.ts
@@ -115,16 +115,18 @@ const DIAGNOSTIC_DEFINITIONS: DiagnosticDefinition[] = [
       const spaShells = (d.spaShells as number) ?? 0;
       const sparseContent = (d.sparseContent as number) ?? 0;
       const total = ((d.serverRendered as number) ?? 0) + sparseContent + spaShells;
-      // Trigger when >25% of pages are SPA shells or sparse
-      return total > 0 && (spaShells + sparseContent) / total > 0.25;
+      // Trigger when >25% of pages are actual SPA shells (empty body post-fetch).
+      // Sparse-but-rendered pages are handled by `sparse-content-html` instead;
+      // conflating the two produced false-positive "client-side rendering"
+      // accusations on sites whose pages are server-rendered but legitimately short.
+      return total > 0 && spaShells / total > 0.25;
     },
     message: (results) => {
       const rs = results.get('rendering-strategy');
       const d = rs?.details;
       const spaShells = (d?.spaShells as number) ?? 0;
       const sparseContent = (d?.sparseContent as number) ?? 0;
-      const affected = spaShells + sparseContent;
-      const total = ((d?.serverRendered as number) ?? 0) + affected;
+      const total = ((d?.serverRendered as number) ?? 0) + sparseContent + spaShells;
 
       const mdSupport = results.get('markdown-url-support');
       const mdNote =
@@ -133,17 +135,71 @@ const DIAGNOSTIC_DEFINITIONS: DiagnosticDefinition[] = [
           : ' Agents currently have no alternative path to content on affected pages.';
 
       return (
-        `${affected} of ${total} sampled pages use client-side rendering. ` +
-        'Agents receive an empty shell for these pages instead of ' +
-        'documentation content. Page size and content structure scores for ' +
-        'the HTML path are discounted because they are partially measuring ' +
-        `shells rather than content.${mdNote}`
+        `${spaShells} of ${total} sampled pages are client-side-rendered ` +
+        'shells: the HTML response contains a framework root element but no ' +
+        'documentation content. Agents using HTTP fetches receive empty pages. ' +
+        'Page size and content structure scores for the HTML path are ' +
+        `discounted because they are partially measuring shells rather than content.${mdNote}`
       );
     },
     resolution:
       'Enable server-side rendering or static generation for affected page ' +
       'types. If only specific page templates use client-side content ' +
       'loading, target those templates rather than rebuilding the entire site.',
+  },
+
+  {
+    id: 'sparse-content-html',
+    severity: 'info',
+    triggers: (results, triggered) => {
+      const rs = results.get('rendering-strategy');
+      if (!rs || rs.status === 'pass' || rs.status === 'skip') return false;
+
+      const d = rs.details;
+      if (!d) return false;
+
+      const spaShells = (d.spaShells as number) ?? 0;
+      const sparseContent = (d.sparseContent as number) ?? 0;
+      const total = ((d.serverRendered as number) ?? 0) + sparseContent + spaShells;
+      if (total === 0) return false;
+
+      // Fire when sparse pages are common AND shells aren't the dominant story.
+      // If `spa-shell-html-invalid` already fired, suppress this one to avoid
+      // double-reporting on mixed sites — the shell diagnostic is the bigger
+      // problem and the resolution covers both.
+      if (triggered.has('spa-shell-html-invalid')) return false;
+      return sparseContent / total > 0.25;
+    },
+    message: (results) => {
+      const rs = results.get('rendering-strategy');
+      const d = rs?.details;
+      const spaShells = (d?.spaShells as number) ?? 0;
+      const sparseContent = (d?.sparseContent as number) ?? 0;
+      const total = ((d?.serverRendered as number) ?? 0) + sparseContent + spaShells;
+
+      const mdSupport = results.get('markdown-url-support');
+      const mdNote =
+        mdSupport?.status === 'pass'
+          ? ' Your markdown path still works for agents that can discover it.'
+          : ' Agents have no alternative path on affected pages, so any missing content is invisible.';
+
+      return (
+        `${sparseContent} of ${total} sampled pages render server-side but ` +
+        'have unusually short body content. The HTML response contains real ' +
+        'content (headings and visible text), just less than the threshold ' +
+        'for a full documentation page. This is often legitimate (short ' +
+        'reference pages, integration one-liners, glossary entries), but ' +
+        'can also indicate a renderer that is not emitting full content. ' +
+        'Page size scoring on the HTML path is discounted for these ' +
+        `pages.${mdNote}`
+      );
+    },
+    resolution:
+      'Verify the affected pages render their full content server-side. If ' +
+      'the pages are intentionally brief, no action is needed; this is ' +
+      'informational. If content is missing, check whether your renderer ' +
+      'is emitting paragraphs, lists, and code blocks server-side rather ' +
+      'than hydrating them client-side.',
   },
 
   {

--- a/test/unit/helpers/detect-rendering.test.ts
+++ b/test/unit/helpers/detect-rendering.test.ts
@@ -179,6 +179,53 @@ describe('analyzeRendering', () => {
     expect(result.hasContent).toBe(true);
   });
 
+  it('passes for div-soup SSR site with a short but real doc page (heading + ~500-1500 chars)', () => {
+    // Simulates Archbee's short integration/explainer pages: __next marker,
+    // single H1, prose wrapped in <div>/<span> rather than <p>, body length
+    // well below the 1500-char wall-of-text threshold but well above an
+    // empty shell. Pages like this ("what is Loom and how to embed it",
+    // "Branches & Reviews", "Figma") are fully server-rendered with real
+    // content; they're just brief.
+    const prose =
+      'Loom is a video messaging tool that lets users record their screen ' +
+      'and camera at the same time. Embed a Loom recording in any Archbee ' +
+      'document by pasting the share URL into a code block. Loom embeds ' +
+      'are useful for onboarding flows, demos, and how-to walkthroughs ' +
+      'where a written explanation alone would be hard to follow. ';
+    const html =
+      '<html><body><div id="__next">' +
+      '<div><h1>Loom</h1></div>' +
+      '<div><span>' +
+      prose.repeat(2) +
+      '</span></div>' +
+      '</div></body></html>';
+    const result = analyzeRendering(html);
+    expect(result.hasSpaMarkers).toBe(true);
+    expect(result.contentHeadings).toBe(1);
+    expect(result.contentParagraphs).toBe(0);
+    expect(result.hasMainContent).toBe(false);
+    expect(result.visibleTextLength).toBeGreaterThanOrEqual(500);
+    expect(result.visibleTextLength).toBeLessThan(1500);
+    expect(result.hasContent).toBe(true);
+  });
+
+  it('still fails for a near-empty SPA shell that has just an H1 and almost no body text', () => {
+    // Guards against the new heading+500-char clause being too permissive.
+    // A real short doc page has at least a few hundred characters of prose;
+    // a true shell with only a server-rendered title and no body should
+    // still fail.
+    const html =
+      '<html><body><div id="__next">' +
+      '<h1>Loading...</h1>' +
+      '<div></div>' +
+      '</div></body></html>';
+    const result = analyzeRendering(html);
+    expect(result.hasSpaMarkers).toBe(true);
+    expect(result.contentHeadings).toBe(1);
+    expect(result.visibleTextLength).toBeLessThan(500);
+    expect(result.hasContent).toBe(false);
+  });
+
   it('handles empty HTML', () => {
     const result = analyzeRendering('');
     expect(result.hasContent).toBe(true); // No SPA markers = assume content

--- a/test/unit/scoring/diagnostics.test.ts
+++ b/test/unit/scoring/diagnostics.test.ts
@@ -152,6 +152,34 @@ describe('diagnostics', () => {
       expect(diags.find((d) => d.id === 'spa-shell-html-invalid')).toBeUndefined();
     });
 
+    it('does not trigger when only sparse content is present (no shells)', () => {
+      // Archbee-style site: server-rendered short pages that the heuristic
+      // classifies as sparse but no actual shells.
+      const results = resultsMap(
+        r('rendering-strategy', 'warn', {
+          serverRendered: 36,
+          sparseContent: 32,
+          spaShells: 0,
+        }),
+      );
+      const diags = evaluateDiagnostics(results, defaultReport());
+      expect(diags.find((d) => d.id === 'spa-shell-html-invalid')).toBeUndefined();
+    });
+
+    it('does not trigger when sparse content is dominant but shells are below threshold', () => {
+      // 1 shell out of 20 = 5%, below 25% threshold — should not fire as
+      // shell diagnostic even though sparse-content-html will fire.
+      const results = resultsMap(
+        r('rendering-strategy', 'warn', {
+          serverRendered: 5,
+          sparseContent: 14,
+          spaShells: 1,
+        }),
+      );
+      const diags = evaluateDiagnostics(results, defaultReport());
+      expect(diags.find((d) => d.id === 'spa-shell-html-invalid')).toBeUndefined();
+    });
+
     it('includes markdown note when available', () => {
       const results = resultsMap(
         r('rendering-strategy', 'fail', {
@@ -164,6 +192,134 @@ describe('diagnostics', () => {
       const diags = evaluateDiagnostics(results, defaultReport());
       const diag = diags.find((d) => d.id === 'spa-shell-html-invalid');
       expect(diag!.message).toContain('markdown path still works');
+    });
+
+    it('describes shells specifically rather than client-side rendering generally', () => {
+      const results = resultsMap(
+        r('rendering-strategy', 'fail', {
+          serverRendered: 5,
+          sparseContent: 0,
+          spaShells: 15,
+        }),
+      );
+      const diags = evaluateDiagnostics(results, defaultReport());
+      const diag = diags.find((d) => d.id === 'spa-shell-html-invalid');
+      expect(diag!.message).toContain('client-side-rendered shells');
+      expect(diag!.message).toContain('15 of 20');
+    });
+  });
+
+  describe('sparse-content-html', () => {
+    it('triggers when >25% of pages are sparse and no shells are present', () => {
+      // Archbee-style: server-rendered short pages
+      const results = resultsMap(
+        r('rendering-strategy', 'warn', {
+          serverRendered: 36,
+          sparseContent: 32,
+          spaShells: 0,
+        }),
+      );
+      const diags = evaluateDiagnostics(results, defaultReport());
+      const diag = diags.find((d) => d.id === 'sparse-content-html');
+      expect(diag).toBeDefined();
+      expect(diag!.severity).toBe('info');
+      expect(diag!.message).toContain('32 of 68');
+    });
+
+    it('does not accuse the site of client-side rendering', () => {
+      const results = resultsMap(
+        r('rendering-strategy', 'warn', {
+          serverRendered: 36,
+          sparseContent: 32,
+          spaShells: 0,
+        }),
+      );
+      const diags = evaluateDiagnostics(results, defaultReport());
+      const diag = diags.find((d) => d.id === 'sparse-content-html');
+      expect(diag!.message).toContain('render server-side');
+      expect(diag!.message).not.toContain('use client-side rendering');
+      expect(diag!.message).not.toContain('empty shell');
+    });
+
+    it('does not trigger when rendering-strategy passes', () => {
+      const results = resultsMap(
+        r('rendering-strategy', 'pass', {
+          serverRendered: 20,
+          sparseContent: 0,
+          spaShells: 0,
+        }),
+      );
+      const diags = evaluateDiagnostics(results, defaultReport());
+      expect(diags.find((d) => d.id === 'sparse-content-html')).toBeUndefined();
+    });
+
+    it('does not trigger when sparse count is below threshold', () => {
+      const results = resultsMap(
+        r('rendering-strategy', 'warn', {
+          serverRendered: 18,
+          sparseContent: 2,
+          spaShells: 0,
+        }),
+      );
+      const diags = evaluateDiagnostics(results, defaultReport());
+      expect(diags.find((d) => d.id === 'sparse-content-html')).toBeUndefined();
+    });
+
+    it('is suppressed when spa-shell-html-invalid already fired', () => {
+      // Mixed case: both shells and sparse over threshold. Shell diagnostic
+      // is the bigger problem; sparse is suppressed to avoid double-reporting.
+      const results = resultsMap(
+        r('rendering-strategy', 'fail', {
+          serverRendered: 3,
+          sparseContent: 5,
+          spaShells: 5,
+        }),
+      );
+      const diags = evaluateDiagnostics(results, defaultReport());
+      expect(diags.find((d) => d.id === 'spa-shell-html-invalid')).toBeDefined();
+      expect(diags.find((d) => d.id === 'sparse-content-html')).toBeUndefined();
+    });
+
+    it('fires when sparse dominates and shells are below threshold', () => {
+      // 1 shell out of 20 = 5%, below 25%. Sparse diagnostic should fire alone.
+      const results = resultsMap(
+        r('rendering-strategy', 'warn', {
+          serverRendered: 5,
+          sparseContent: 14,
+          spaShells: 1,
+        }),
+      );
+      const diags = evaluateDiagnostics(results, defaultReport());
+      expect(diags.find((d) => d.id === 'spa-shell-html-invalid')).toBeUndefined();
+      expect(diags.find((d) => d.id === 'sparse-content-html')).toBeDefined();
+    });
+
+    it('includes markdown note when markdown path is available', () => {
+      const results = resultsMap(
+        r('rendering-strategy', 'warn', {
+          serverRendered: 36,
+          sparseContent: 32,
+          spaShells: 0,
+        }),
+        r('markdown-url-support', 'pass'),
+      );
+      const diags = evaluateDiagnostics(results, defaultReport());
+      const diag = diags.find((d) => d.id === 'sparse-content-html');
+      expect(diag!.message).toContain('markdown path still works');
+    });
+
+    it('notes no alternative path when markdown unavailable', () => {
+      const results = resultsMap(
+        r('rendering-strategy', 'warn', {
+          serverRendered: 36,
+          sparseContent: 32,
+          spaShells: 0,
+        }),
+        r('markdown-url-support', 'fail'),
+      );
+      const diags = evaluateDiagnostics(results, defaultReport());
+      const diag = diags.find((d) => d.id === 'sparse-content-html');
+      expect(diag!.message).toContain('no alternative path');
     });
   });
 


### PR DESCRIPTION
  ## Summary

Two related fixes for `rendering-strategy`, prompted by Archbee scoring as having a third of its pages "use client-side rendering" when in fact every sampled page was fully server-rendered — they were just brief.

### 1. Split `spa-shell-html-invalid` into two distinct diagnostics

The diagnostic previously fired whenever the warn-or-fail proportion exceeded 25%, but its message claimed pages used client-side rendering. That was correct for actual shells but wrong for sparse-but-rendered pages, which is the larger bucket in practice.

- `spa-shell-html-invalid` now fires only on actual SPA shells (`spaShells / total > 0.25`) and keeps its strong "client-side rendering invalidates the HTML path" message.
- New `sparse-content-html` fires on sparse pages (`sparseContent / total > 0.25`), suppressed when the shell diagnostic already fired. Its message and resolution direct readers to spot-check rather than assume a renderer bug.

### 2. Loosen the heuristic so legitimately short doc pages pass

`detect-rendering` previously required `visibleTextLength >= 1500` (after chrome stripping) as the wall-of-text fallback. Archbee's short integration explainers (Loom, Figma, Branches & Reviews) sat at 589–1485 chars of real prose and got flagged as sparse. Real shells, by contrast, post-strip to ~0 chars — the gap is much wider than 1500 implied.

Added a new clause to the `hasContent` disjunction:

```ts
(contentHeadings >= 1 && visibleTextLength >= 500)
```

A heading plus 500+ characters of post-chrome-strip body is well above any actual shell and well below what's needed to admit one. Two new tests cover both sides: a div-soup short page (passes) and an `<h1>Loading…</h1>` shell with empty body (still fails).

**Impact**

Archbee re-scored: serverRendered 36→68, sparseContent 32→0, page-size 89→100, overall 78→80 (B).

**Doc updates**

The split and the proportion math touched several docs. Updated:
- docs/agent-score-calculation.md, docs/checks/page-size.md, docs/improve-your-score.md
- docs/interaction-diagnostics.md (new sparse-content section, updated shell section)
- SCORING.md, scoring-reference.md

Score-cap labels changed from "75%+/50%+ SPA shells" to proportion-based language reflecting the actual formula: (serverRendered + sparseContent × 0.5) / total. SPEC.md needed no changes — it already specifies the three result levels accurately.

**Test plan**

- All 1,231 tests pass
- Lint and typecheck clean
- Re-ran Archbee end-to-end and confirmed expected score change
- Spot-check at least one other site previously flagged for sparse content to confirm no regression