### PR TITLE
fix: reject info-string lines as code-fence closers

### DIFF
--- a/src/checks/content-structure/markdown-code-fence-validity.ts
+++ b/src/checks/content-structure/markdown-code-fence-validity.ts
@@ -45,17 +45,18 @@ function analyzeFences(content: string): { fenceCount: number; issues: FenceIssu
 
     const char = match[3] ? '`' : '~';
     const length = (match[3] || match[4]).length;
+    const info = (match[5] || '').trim();
 
     if (!openFence) {
       // Opening fence
       openFence = { line: i + 1, char, length };
       fenceCount++;
     } else {
-      // Potential closing fence: must use same char and be at least as long.
-      // Per CommonMark spec, backtick fences are only closed by backtick fences
-      // and tilde fences are only closed by tilde fences. A different delimiter
-      // type is just content inside the fence, not a closer.
-      if (char === openFence.char && length >= openFence.length) {
+      // Potential closing fence: must use same char, be at least as long,
+      // and per CommonMark §4.5 "may not be followed by anything other than
+      // spaces and tabs" — a fence line carrying an info string is content,
+      // not a closer. Different delimiter types are also just content.
+      if (char === openFence.char && length >= openFence.length && info === '') {
         openFence = null;
       }
     }

--- a/test/unit/checks/markdown-code-fence-validity.test.ts
+++ b/test/unit/checks/markdown-code-fence-validity.test.ts
@@ -96,6 +96,31 @@ describe('markdown-code-fence-validity', () => {
     expect(result.details?.unclosedCount).toBe(1);
   });
 
+  it('does not treat a longer fence line carrying an info string as a closer', async () => {
+    // Per CommonMark §4.5, a closing fence "may not be followed by
+    // anything other than spaces and tabs" — i.e. it cannot have an
+    // info string. Inside an open fence, a longer line that looks like
+    // a fence opener (more backticks plus an info string) is just text,
+    // not a closer; the next bare matching fence line is the closer.
+    //
+    // Realistic case: a docs page explains fence syntax to readers, and
+    // its prose includes a line starting with four backticks as the
+    // illustrated syntax.
+    const md = [
+      '```', // opens the outer fence
+      'In GitHub-flavored markdown you can attach attributes to a fence:',
+      '````md filename="example.md"', // looks like a fence, but is prose inside the open fence
+      'The closing fence matches the opening fence length, with no info.',
+      '```', // closes the outer fence
+    ].join('\n');
+    const result = await check.run(
+      makeCtx([{ url: 'http://test.local/page1', content: md, source: 'md-url' }]),
+    );
+    expect(result.status).toBe('pass');
+    expect(result.details?.totalFences).toBe(1);
+    expect(result.details?.unclosedCount).toBe(0);
+  });
+
   it('allows valid cross-type nesting (backtick fence containing tilde fence)', async () => {
     // A ``` fence can contain ~~~ fences because they are different delimiter types
     const md = [


### PR DESCRIPTION
The `markdown-code-fence-validity` accepts any matching number of ``` backticks as a valid terminator for a fence.

That is a problem for this kind of fenced content:

````md
```
content
``` filename="foo.rs"
```
````

The current parser ends the block at the ```filename="foo.rs" - but that's not following spec. See what Github renders:

```
content
``` filename="foo.rs"
```

One block. Another example, similar to the unit test - though the unit test uses 4 backticks.

```
In GitHub-flavored markdown you can attach attributes to a fence:
```md filename="example.md"
The closing fence matches the opening fence length, with no info.
```