### PR TITLE
fix(auth): suppress auth-no-alternative when fetches fail from network errors

### DIFF
--- a/src/checks/authentication/auth-alternative-access.ts
+++ b/src/checks/authentication/auth-alternative-access.ts
@@ -7,6 +7,7 @@ interface AuthGateDetails {
   softAuthGate?: number;
   authRedirect?: number;
   testedPages?: number;
+  fetchErrors?: number;
   pageResults?: Array<{
     url: string;
     classification: string;
@@ -59,6 +60,20 @@ async function check(ctx: CheckContext): Promise<CheckResult> {
     (authDetails.authRedirect ?? 0);
   const accessibleCount = authDetails.accessible ?? 0;
   const testedCount = authDetails.testedPages ?? 0;
+  const fetchErrors = authDetails.fetchErrors ?? 0;
+
+  // If auth-gate-detection failed solely because pages couldn't be fetched
+  // (DNS failure, network error, etc.) rather than from detected auth responses,
+  // we have no signal about authentication. Skip rather than imply an auth problem.
+  if (gatedCount === 0 && fetchErrors > 0) {
+    return {
+      id,
+      category,
+      status: 'skip',
+      message:
+        'auth-gate-detection failed due to fetch errors, not detected auth responses; cannot assess alternative access',
+    };
+  }
 
   const detectedPaths: DetectedPath[] = [];
 

--- a/test/unit/checks/auth-alternative-access.test.ts
+++ b/test/unit/checks/auth-alternative-access.test.ts
@@ -71,6 +71,31 @@ describe('auth-alternative-access', () => {
     expect(result.message).toContain('errored');
   });
 
+  it('skips when auth-gate-detection failed due to fetch errors only', async () => {
+    // Simulates the early-return path in auth-gate-detection where every page
+    // failed to fetch (e.g. DNS NXDOMAIN). Details include fetchErrors but no
+    // gated/accessible counts. We should not emit auth-no-alternative here.
+    const result = await check.run(
+      makeCtx(
+        authGateResult('fail', {
+          totalPages: 1,
+          testedPages: 1,
+          fetchErrors: 1,
+          pageResults: [
+            {
+              url: 'https://example-domain-not-resolving.com',
+              classification: 'accessible',
+              status: null,
+              error: 'fetch failed',
+            },
+          ],
+        }),
+      ),
+    );
+    expect(result.status).toBe('skip');
+    expect(result.message).toContain('fetch errors');
+  });
+
   it('skips when auth-gate-detection was skipped', async () => {
     const result = await check.run(
       makeCtx({


### PR DESCRIPTION
## Summary
- Skip `auth-alternative-access` when `auth-gate-detection` fails solely due to fetch errors (DNS NXDOMAIN, network error, etc.) rather than detected auth responses
- Prevents the `auth-no-alternative` critical diagnostic from firing as a false positive on unreachable sites — `no-viable-path` already correctly captures the unreachability case
- Fixes #85

## Test plan
- [x] New unit test in `test/unit/checks/auth-alternative-access.test.ts` simulates the all-fetch-errors details shape from the issue and asserts the check skips
- [x] Full test suite passes (1290/1290) and `tsc --noEmit` is clean
- [x] Manually verified against `https://rapidocweb.com` (the original reproducer): `auth-alternative-access` now returns `skip` with the expected message and `auth-no-alternative` is no longer in the diagnostics list