### PR TITLE
fix: detect fetch-blocked ports up front instead of failing every check

### DIFF
--- a/docs/run-locally.md
+++ b/docs/run-locally.md
@@ -18,11 +18,11 @@ npx afdocs check http://localhost:3000
 ## Pick a safe port
 
 AFDocs fetches pages with Node's built-in `fetch`, which implements the
-WHATWG fetch spec, including its [bad port list](https://fetch.spec.whatwg.org/#port-blocking). Requests to a blocked port are refused before they reach the network, so if your dev server happens to be on one, every check reports a fetch error ("fetch failed", status 0) even though the server is running and `curl` works fine.
+WHATWG fetch spec, including its [bad port list](https://fetch.spec.whatwg.org/#port-blocking). Requests to a blocked port are refused before they reach the network, so a dev server on one of those ports is reachable by your browser and `curl` but not by AFDocs.
 
-The common dev ports (3000, 4321, 5173, 8080, and Hugo's 1313) are all safe. The traps are ports reserved for other protocols that look reasonable for a dev server, like 1719 and 1720 (H.323), 6000 (X11), or 6667 (IRC).
+AFDocs detects this before running any checks and exits with an error naming the port, so a blocked port never shows up as a wall of "fetch failed" check results.
 
-If AFDocs reports fetch errors on every check while the site loads fine in your browser or with `curl`, check the port before debugging anything else. Moving the dev server to another port is the whole fix:
+The common dev ports (3000, 4321, 5173, 8080, and Hugo's 1313) are all safe. The traps are ports reserved for other protocols that look reasonable for a dev server, like 1719 and 1720 (H.323), 6000 (X11), or 6667 (IRC). Moving the dev server to another port is the whole fix:
 
 ```bash
 hugo server -p 1721   # not 1719

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -298,7 +298,14 @@ export function registerCheckCommand(program: Command): void {
         process.stderr.write(`Warning: ${warn.message}\n`);
       }
 
-      const report = await runChecks(url, runnerOptions);
+      let report;
+      try {
+        report = await runChecks(url, runnerOptions);
+      } catch (err) {
+        process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
+        process.exitCode = 1;
+        return;
+      }
 
       let output: string;
       if (format === 'json') {

--- a/src/helpers/blocked-ports.ts
+++ b/src/helpers/blocked-ports.ts
@@ -1,0 +1,50 @@
+// Ports on the WHATWG fetch spec's bad port list.
+// https://fetch.spec.whatwg.org/#port-blocking
+//
+// Node's built-in fetch (undici) refuses to connect to these ports before any
+// network request is made, so every check against a target on one of them
+// fails with a bare "fetch failed". undici implements the list but doesn't
+// export it; it's small and stable (changes only via fetch spec updates), so
+// we vendor it to diagnose the problem up front.
+const BLOCKED_PORTS = new Set([
+  1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69, 77, 79, 87, 95, 101, 102,
+  103, 104, 109, 110, 111, 113, 115, 117, 119, 123, 135, 137, 139, 143, 161, 179, 389, 427, 465,
+  512, 513, 514, 515, 526, 530, 531, 532, 540, 548, 554, 556, 563, 587, 601, 636, 989, 990, 993,
+  995, 1719, 1720, 1723, 2049, 3659, 4045, 4190, 5060, 5061, 6000, 6566, 6665, 6666, 6667, 6668,
+  6669, 6679, 6697, 10080,
+]);
+
+/**
+ * Returns true if the port is on the WHATWG fetch blocked-port list.
+ */
+export function isBlockedPort(port: number): boolean {
+  return BLOCKED_PORTS.has(port);
+}
+
+/**
+ * If the URL targets a blocked port, return that port number; otherwise null.
+ * Only http/https URLs with an explicit non-default port can be blocked.
+ */
+export function getBlockedPort(url: string): number | null {
+  try {
+    const parsed = new URL(url);
+    if (!parsed.port) return null;
+    const port = parseInt(parsed.port, 10);
+    return isBlockedPort(port) ? port : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the actionable error message for a blocked-port target.
+ */
+export function blockedPortMessage(port: number): string {
+  return (
+    `Port ${port} is on the WHATWG fetch blocked-port list ` +
+    `(https://fetch.spec.whatwg.org/#port-blocking); Node's fetch refuses to ` +
+    `connect to it, so every check would fail with "fetch failed". Restart ` +
+    `your dev server on a different port (1313, 3000, and 5173 are all safe) ` +
+    `and re-run.`
+  );
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -3,6 +3,7 @@ import { DEFAULT_OPTIONS, SPEC_BASE_URL } from './constants.js';
 import { createHttpClient } from './http.js';
 import { getChecksSorted } from './checks/registry.js';
 import { validateRunnerOptions } from './validation.js';
+import { getBlockedPort, blockedPortMessage } from './helpers/blocked-ports.js';
 
 /**
  * Normalize dependsOn to the internal format: array of OR-groups.
@@ -59,6 +60,14 @@ export function createContext(baseUrl: string, options?: Partial<RunnerOptions>)
   const merged = { ...DEFAULT_OPTIONS, ...options };
   baseUrl = normalizeUrl(baseUrl);
   const url = new URL(baseUrl);
+
+  // Fail fast when the target port is on the WHATWG fetch bad port list:
+  // undici would refuse every request, turning one port choice into a wall
+  // of opaque "fetch failed" errors.
+  const blockedPort = getBlockedPort(baseUrl);
+  if (blockedPort !== null) {
+    throw new Error(blockedPortMessage(blockedPort));
+  }
 
   return {
     baseUrl: baseUrl.replace(/\/$/, ''),

--- a/test/unit/helpers/blocked-ports.test.ts
+++ b/test/unit/helpers/blocked-ports.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isBlockedPort,
+  getBlockedPort,
+  blockedPortMessage,
+} from '../../../src/helpers/blocked-ports.js';
+
+describe('isBlockedPort', () => {
+  it('returns true for ports on the WHATWG bad port list', () => {
+    expect(isBlockedPort(1719)).toBe(true); // H.323 gatestat
+    expect(isBlockedPort(1720)).toBe(true); // H.323 hostcall
+    expect(isBlockedPort(6000)).toBe(true); // X11
+    expect(isBlockedPort(6667)).toBe(true); // IRC
+    expect(isBlockedPort(22)).toBe(true); // SSH
+    expect(isBlockedPort(10080)).toBe(true); // amanda
+  });
+
+  it('returns false for common dev server ports', () => {
+    expect(isBlockedPort(1313)).toBe(false); // Hugo
+    expect(isBlockedPort(3000)).toBe(false);
+    expect(isBlockedPort(4321)).toBe(false); // Astro
+    expect(isBlockedPort(5173)).toBe(false); // Vite
+    expect(isBlockedPort(8080)).toBe(false);
+  });
+});
+
+describe('getBlockedPort', () => {
+  it('returns the port when the URL targets a blocked port', () => {
+    expect(getBlockedPort('http://localhost:1719')).toBe(1719);
+    expect(getBlockedPort('http://127.0.0.1:6000/docs')).toBe(6000);
+  });
+
+  it('returns null for URLs on safe ports', () => {
+    expect(getBlockedPort('http://localhost:1313')).toBeNull();
+    expect(getBlockedPort('http://localhost:3000/docs')).toBeNull();
+  });
+
+  it('returns null when no explicit port is present', () => {
+    expect(getBlockedPort('https://example.com/docs')).toBeNull();
+    expect(getBlockedPort('http://localhost')).toBeNull();
+  });
+
+  it('returns null for malformed URLs', () => {
+    expect(getBlockedPort('not a url')).toBeNull();
+  });
+});
+
+describe('blockedPortMessage', () => {
+  it('names the port and suggests safe alternatives', () => {
+    const msg = blockedPortMessage(1719);
+    expect(msg).toContain('1719');
+    expect(msg).toContain('blocked-port list');
+    expect(msg).toContain('different port');
+  });
+});

--- a/test/unit/runner.test.ts
+++ b/test/unit/runner.test.ts
@@ -81,6 +81,16 @@ describe('createContext URL normalization', () => {
     );
   });
 
+  it('throws an actionable error when the target port is fetch-blocked', () => {
+    expect(() => createContext('http://localhost:1719')).toThrow(/blocked-port list/);
+    expect(() => createContext('http://localhost:1719')).toThrow(/1719/);
+  });
+
+  it('does not throw for safe local dev ports', () => {
+    expect(() => createContext('http://localhost:1313')).not.toThrow();
+    expect(() => createContext('http://localhost:5173')).not.toThrow();
+  });
+
   it('normalizes bare domain in canonicalOrigin', () => {
     const ctx = createContext('https://preview.example.com', {
       canonicalOrigin: 'example.com',


### PR DESCRIPTION
## Summary
- Vendor the WHATWG fetch [bad port list](https://fetch.spec.whatwg.org/#port-blocking) in a new `src/helpers/blocked-ports.ts` helper (undici implements the list but does not export it)
- Fail fast in `createContext` when the target URL's port is on the list, with an error naming the port and suggesting safe alternatives, instead of thirteen opaque "fetch failed" check results
- Catch runner errors in the `check` command and print them cleanly (previously a thrown runner error surfaced as an unhandled rejection)
- Update the "Pick a safe port" section of `docs/run-locally.md` to reflect that the tool now diagnoses this directly

Closes #97

## Test plan
- [x] Unit tests for `isBlockedPort` / `getBlockedPort` / `blockedPortMessage` and for `createContext` throwing on blocked ports
- [x] `npm test` (1304 tests), `npm run lint`, prettier clean
- [x] Manual: `afdocs check http://localhost:1719` exits 1 with the actionable error; safe ports unaffected