### PR TITLE
fix(coverage): detect minority-locale translations and honor --doc-locale

### DIFF
--- a/docs/checks/observability.md
+++ b/docs/checks/observability.md
@@ -52,6 +52,14 @@ options:
     - '**/release-notes/**' # quote patterns starting with *
 ```
 
+### Locale handling
+
+Multi-locale sites usually list only one language in `llms.txt`, so localized sitemap URLs would otherwise read as missing coverage. The check detects locale-prefixed paths (like `/fr/` or `/docs/ja/`) and compares `llms.txt` against a single locale:
+
+- When locale prefixes cover most of the sitemap, the prefix position is detected directly.
+- When translations are a minority of the sitemap (an unprefixed default language plus a few translated locales), the check confirms the prefixes by structural duplication: stripping a locale code must produce paths that match unprefixed URLs.
+- `--doc-locale <code>` (or `preferredLocale` in config) overrides detection. If the sitemap has no URLs prefixed with that locale, it is treated as the unprefixed default and the localized variants are excluded.
+
 ### How to fix
 
 **If this check warns or fails**, regenerate `llms.txt` from your sitemap or build pipeline. The best long-term fix is generating `llms.txt` at build time, so every deployment automatically includes an up-to-date index. Run with `--verbose` to see which pages are missing. If the missing pages are intentionally excluded, use `--coverage-exclusions` or adjust thresholds.

--- a/src/checks/observability/llms-txt-coverage.ts
+++ b/src/checks/observability/llms-txt-coverage.ts
@@ -163,13 +163,15 @@ export function detectLocalePosition(urls: string[]): number | null {
     }
   }
 
-  // Second pass: single locale code confirmed by structural duplication.
-  // With ISO 639-1 validation, a single code is meaningful when stripping it
-  // produces paths that match unprefixed URLs in the same set.
+  // Second pass: locale codes below the coverage threshold, confirmed by
+  // structural duplication: stripping a code must produce paths that match
+  // unprefixed URLs in the same set. This catches multi-locale sites whose
+  // default locale is unprefixed and whose translations are a minority of
+  // the sitemap (e.g. /fr/, /ja/, /ko/, /es/ at 40% of URLs), as well as
+  // the single-locale case.
   for (const [pos, counts] of positionCounts) {
-    if (counts.size !== 1) continue;
-    const [code] = counts.keys();
-    if (hasStructuralDuplication(urls, pos, code)) {
+    const codes = [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([code]) => code);
+    if (codes.some((code) => hasStructuralDuplication(urls, pos, code))) {
       return pos;
     }
   }
@@ -397,22 +399,41 @@ async function check(ctx: CheckContext): Promise<CheckResult> {
   const localePosition = detectLocalePosition(scopedSitemapUrls);
 
   if (localePosition !== null) {
-    const llmsLocale = getDominantSegment(llmsTxtUrls, localePosition);
-    if (llmsLocale) {
-      detectedLocale = llmsLocale;
+    const preferred = ctx.options.preferredLocale?.toLowerCase();
+    if (preferred) {
+      // Explicit locale (--doc-locale / config preferredLocale) wins over
+      // inference from llms.txt URLs.
+      const byPreferred = filterByLocale(scopedSitemapUrls, preferred, localePosition);
       const before = scopedSitemapUrls.length;
-      scopedSitemapUrls = filterByLocale(scopedSitemapUrls, llmsLocale, localePosition);
-      localeFiltered = scopedSitemapUrls.length < before;
-    } else {
-      // llms.txt may cover the unprefixed default locale (no /en/, /de/, etc.).
-      // If most llms.txt URLs lack locale codes at the detected position,
-      // filter the sitemap to only unprefixed URLs.
-      const withLocale = llmsTxtUrls.filter((u) => hasLocaleCodeAt(u, localePosition!)).length;
-      if (withLocale < llmsTxtUrls.length * 0.5) {
-        const before = scopedSitemapUrls.length;
+      if (byPreferred.length > 0) {
+        scopedSitemapUrls = byPreferred;
+        localeFiltered = scopedSitemapUrls.length < before;
+        if (localeFiltered) detectedLocale = preferred;
+      } else {
+        // No URLs carry the preferred locale as a prefix, so it must be the
+        // unprefixed default locale: drop the locale-prefixed translations.
         scopedSitemapUrls = filterToUnprefixedLocale(scopedSitemapUrls, localePosition);
         localeFiltered = scopedSitemapUrls.length < before;
         if (localeFiltered) detectedLocale = 'default';
+      }
+    } else {
+      const llmsLocale = getDominantSegment(llmsTxtUrls, localePosition);
+      if (llmsLocale) {
+        detectedLocale = llmsLocale;
+        const before = scopedSitemapUrls.length;
+        scopedSitemapUrls = filterByLocale(scopedSitemapUrls, llmsLocale, localePosition);
+        localeFiltered = scopedSitemapUrls.length < before;
+      } else {
+        // llms.txt may cover the unprefixed default locale (no /en/, /de/, etc.).
+        // If most llms.txt URLs lack locale codes at the detected position,
+        // filter the sitemap to only unprefixed URLs.
+        const withLocale = llmsTxtUrls.filter((u) => hasLocaleCodeAt(u, localePosition!)).length;
+        if (withLocale < llmsTxtUrls.length * 0.5) {
+          const before = scopedSitemapUrls.length;
+          scopedSitemapUrls = filterToUnprefixedLocale(scopedSitemapUrls, localePosition);
+          localeFiltered = scopedSitemapUrls.length < before;
+          if (localeFiltered) detectedLocale = 'default';
+        }
       }
     }
   }

--- a/test/unit/checks/llms-txt-coverage.test.ts
+++ b/test/unit/checks/llms-txt-coverage.test.ts
@@ -6,6 +6,7 @@ import { createContext } from '../../../src/runner.js';
 import type { DiscoveredFile } from '../../../src/types.js';
 import { mockSitemapNotFound } from '../../helpers/mock-sitemap-not-found.js';
 import {
+  detectLocalePosition,
   hasLocaleCodeAt,
   filterToUnprefixedLocale,
   compileExclusionMatcher,
@@ -47,9 +48,14 @@ function makeSitemapIndex(sitemapUrls: string[]): string {
 /**
  * Create a test context with llms-txt-exists populated.
  */
-function makeCtx(host: string, llmsTxtUrls: string[], basePath = '') {
+function makeCtx(
+  host: string,
+  llmsTxtUrls: string[],
+  basePath = '',
+  options: Record<string, unknown> = {},
+) {
   const baseUrl = `http://${host}${basePath}`;
-  const ctx = createContext(baseUrl, { requestDelay: 0 });
+  const ctx = createContext(baseUrl, { requestDelay: 0, ...options });
   const content = makeLlmsTxt(llmsTxtUrls);
   const discovered: DiscoveredFile[] = [
     { url: `http://${host}/llms.txt`, content, status: 200, redirected: false },
@@ -674,6 +680,158 @@ describe('llms-txt-coverage', () => {
     expect(result.details?.localeFiltered).toBe(true);
   });
 
+  test('filters minority-locale translations when localized URLs are under 50% of the sitemap', async () => {
+    const host = 'minority-locale.local';
+    // Datadog-style: default English is unprefixed, four translated locales
+    // collectively cover well under half the sitemap.
+    const llmsPages = [
+      `http://${host}/docs/getting-started`,
+      `http://${host}/docs/api-reference`,
+      `http://${host}/docs/guides`,
+      `http://${host}/docs/integrations`,
+      `http://${host}/docs/dashboards`,
+      `http://${host}/docs/alerts`,
+    ];
+
+    // 6 unprefixed + 4 localized (40% of 10 URLs, four distinct codes)
+    const sitemapPages = [
+      ...llmsPages,
+      `http://${host}/docs/fr/getting-started`,
+      `http://${host}/docs/ja/api-reference`,
+      `http://${host}/docs/ko/guides`,
+      `http://${host}/docs/es/integrations`,
+    ];
+
+    const ctx = makeCtx(host, llmsPages, '/docs');
+
+    server.use(
+      http.get(
+        `http://${host}/robots.txt`,
+        () => new HttpResponse(`Sitemap: http://${host}/sitemap.xml`, { status: 200 }),
+      ),
+      http.get(
+        `http://${host}/sitemap.xml`,
+        () =>
+          new HttpResponse(makeSitemap(sitemapPages), {
+            headers: { 'content-type': 'application/xml' },
+          }),
+      ),
+    );
+
+    const result = await check.run(ctx);
+    expect(result.status).toBe('pass');
+    expect(result.details?.sitemapDocPages).toBe(6);
+    expect(result.details?.localeFiltered).toBe(true);
+    expect(result.details?.detectedLocale).toBe('default');
+  });
+
+  test('does not filter locale-like path segments without structural duplication', async () => {
+    const host = 'topic-segments.local';
+    // "it" is a valid ISO 639-1 code but here it's a topic segment (IT docs)
+    // with no unprefixed twins, so it must stay in the denominator.
+    const llmsPages = [
+      `http://${host}/docs/getting-started`,
+      `http://${host}/docs/api-reference`,
+      `http://${host}/docs/it/service-management`,
+      `http://${host}/docs/it/asset-tracking`,
+    ];
+
+    const ctx = makeCtx(host, llmsPages, '/docs');
+
+    server.use(
+      http.get(
+        `http://${host}/robots.txt`,
+        () => new HttpResponse(`Sitemap: http://${host}/sitemap.xml`, { status: 200 }),
+      ),
+      http.get(
+        `http://${host}/sitemap.xml`,
+        () =>
+          new HttpResponse(makeSitemap(llmsPages), {
+            headers: { 'content-type': 'application/xml' },
+          }),
+      ),
+    );
+
+    const result = await check.run(ctx);
+    expect(result.status).toBe('pass');
+    expect(result.details?.sitemapDocPages).toBe(4);
+    expect(result.details?.localeFiltered).toBeUndefined();
+  });
+
+  test('honors explicit preferredLocale when filtering locale-prefixed URLs', async () => {
+    const host = 'preferred-locale.local';
+    const frPages = [
+      `http://${host}/docs/fr/getting-started`,
+      `http://${host}/docs/fr/api-reference`,
+      `http://${host}/docs/fr/guides`,
+    ];
+    const sitemapPages = [
+      `http://${host}/docs/getting-started`,
+      `http://${host}/docs/api-reference`,
+      `http://${host}/docs/guides`,
+      ...frPages,
+    ];
+
+    const ctx = makeCtx(host, frPages, '/docs', { preferredLocale: 'fr' });
+
+    server.use(
+      http.get(
+        `http://${host}/robots.txt`,
+        () => new HttpResponse(`Sitemap: http://${host}/sitemap.xml`, { status: 200 }),
+      ),
+      http.get(
+        `http://${host}/sitemap.xml`,
+        () =>
+          new HttpResponse(makeSitemap(sitemapPages), {
+            headers: { 'content-type': 'application/xml' },
+          }),
+      ),
+    );
+
+    const result = await check.run(ctx);
+    expect(result.status).toBe('pass');
+    expect(result.details?.sitemapDocPages).toBe(3);
+    expect(result.details?.localeFiltered).toBe(true);
+    expect(result.details?.detectedLocale).toBe('fr');
+  });
+
+  test('treats preferredLocale with no prefixed URLs as the unprefixed default', async () => {
+    const host = 'preferred-default.local';
+    const llmsPages = [
+      `http://${host}/docs/getting-started`,
+      `http://${host}/docs/api-reference`,
+      `http://${host}/docs/guides`,
+    ];
+    const sitemapPages = [
+      ...llmsPages,
+      `http://${host}/docs/fr/getting-started`,
+      `http://${host}/docs/fr/api-reference`,
+      `http://${host}/docs/fr/guides`,
+    ];
+
+    const ctx = makeCtx(host, llmsPages, '/docs', { preferredLocale: 'en' });
+
+    server.use(
+      http.get(
+        `http://${host}/robots.txt`,
+        () => new HttpResponse(`Sitemap: http://${host}/sitemap.xml`, { status: 200 }),
+      ),
+      http.get(
+        `http://${host}/sitemap.xml`,
+        () =>
+          new HttpResponse(makeSitemap(sitemapPages), {
+            headers: { 'content-type': 'application/xml' },
+          }),
+      ),
+    );
+
+    const result = await check.run(ctx);
+    expect(result.status).toBe('pass');
+    expect(result.details?.sitemapDocPages).toBe(3);
+    expect(result.details?.localeFiltered).toBe(true);
+    expect(result.details?.detectedLocale).toBe('default');
+  });
+
   test('uses effectiveOrigin for sitemap discovery and scoping', async () => {
     const oldHost = 'old-host.local';
     const newHost = 'new-host.local';
@@ -773,6 +931,53 @@ describe('llms-txt-coverage', () => {
     // Only 2 doc pages remain after excluding /docs/blog and /docs/pricing
     expect(result.details?.sitemapDocPages).toBe(2);
     expect(result.details?.excludedNonDocPages).toBe(3);
+  });
+});
+
+describe('detectLocalePosition', () => {
+  test('detects locale position when locale URLs are the majority', () => {
+    const urls = [
+      'http://x.com/docs/en/intro',
+      'http://x.com/docs/en/api',
+      'http://x.com/docs/de/intro',
+      'http://x.com/docs/de/api',
+      'http://x.com/docs/changelog',
+    ];
+    expect(detectLocalePosition(urls)).toBe(1);
+  });
+
+  test('detects minority multi-locale prefixes via structural duplication', () => {
+    // 6 unprefixed + 4 localized (40%): below the majority threshold, but
+    // stripping each locale code produces paths matching unprefixed URLs.
+    const urls = [
+      'http://x.com/docs/intro',
+      'http://x.com/docs/api',
+      'http://x.com/docs/guides',
+      'http://x.com/docs/integrations',
+      'http://x.com/docs/dashboards',
+      'http://x.com/docs/alerts',
+      'http://x.com/docs/fr/intro',
+      'http://x.com/docs/ja/api',
+      'http://x.com/docs/ko/guides',
+      'http://x.com/docs/es/integrations',
+    ];
+    expect(detectLocalePosition(urls)).toBe(1);
+  });
+
+  test('returns null for minority locale-like codes without structural duplication', () => {
+    // "it" is a valid ISO 639-1 code but has no unprefixed twins here.
+    const urls = [
+      'http://x.com/docs/intro',
+      'http://x.com/docs/api',
+      'http://x.com/docs/it/service-management',
+      'http://x.com/docs/it/asset-tracking',
+    ];
+    expect(detectLocalePosition(urls)).toBeNull();
+  });
+
+  test('returns null when no locale codes appear', () => {
+    const urls = ['http://x.com/docs/intro', 'http://x.com/docs/api'];
+    expect(detectLocalePosition(urls)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- `detectLocalePosition` only recognized multi-locale prefixes when locale codes covered >50% of sitemap URLs, so sites with an unprefixed default language and minority translations (Datadog's `/fr/`, `/ja/`, `/ko/`, `/es/` at ~42%) kept translated pages in the `llms-txt-coverage` denominator
- Generalizes the structural-duplication fallback from the single-code case to any number of locale codes: a position counts as a locale position if stripping one of its codes produces paths that match unprefixed URLs in the same set, so locale-like topic segments (e.g. `/it/` for IT docs) still aren't filtered
- Honors an explicit `--doc-locale` / `preferredLocale` in the coverage check: it wins over inference from llms.txt URLs, and a preferred locale with no prefixed sitemap URLs is treated as the unprefixed default
- Documents locale handling in `docs/checks/observability.md`

Closes #98

## Test plan
- [x] Unit tests for `detectLocalePosition` (majority, minority-with-duplication, locale-like-without-duplication, none)
- [x] Integration tests: Datadog-style minority-locale filtering, topic-segment non-filtering, explicit `--doc-locale` (prefixed and unprefixed-default)
- [x] `npm test` (1303 tests), `npm run lint`, prettier clean