### PR TITLE
feat: add --url-path-pattern flag for llms.txt .md link mapping

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -115,10 +115,11 @@ afdocs check https://docs.example.com --max-links 100
 
 ### URL discovery
 
-| Flag                      | Default     | Description                                                      |
-| ------------------------- | ----------- | ---------------------------------------------------------------- |
-| `--doc-locale <code>`     | auto-detect | Preferred locale for URL discovery (e.g. `en`, `fr`, `ja`)       |
-| `--doc-version <version>` | auto-detect | Preferred version for URL discovery (e.g. `v3`, `2.x`, `latest`) |
+| Flag                           | Default     | Description                                                         |
+| ------------------------------ | ----------- | ------------------------------------------------------------------- |
+| `--doc-locale <code>`          | auto-detect | Preferred locale for URL discovery (e.g. `en`, `fr`, `ja`)          |
+| `--doc-version <version>`      | auto-detect | Preferred version for URL discovery (e.g. `v3`, `2.x`, `latest`)    |
+| `--url-path-pattern <pattern>` | `clean`     | How llms.txt `.md` links map to page URLs: `clean`, `html`, or `md` |
 
 When `afdocs` discovers pages from a sitemap or `llms.txt`, it automatically filters out duplicate locale and version variants so you get a representative sample of unique content.
 
@@ -140,6 +141,18 @@ afdocs check https://docs.example.com --doc-version v3
 # Both together
 afdocs check https://docs.example.com --doc-locale ja --doc-version 2.x
 ```
+
+When llms.txt links end in `.md`, `afdocs` derives each page's canonical URL from the link. The default (`clean`) strips the extension (`/guide.md` → `/guide`), which matches sites with extensionless URLs. If your site serves real filenames, that derived URL may 404 or redirect and skew results. Use `--url-path-pattern` to match your site's URL structure:
+
+```bash
+# Site serves .html pages: /guide.md → /guide.html
+afdocs check https://docs.example.com --url-path-pattern html
+
+# Site serves markdown files directly: /guide.md stays /guide.md
+afdocs check https://docs.example.com --url-path-pattern md
+```
+
+The same option is available in `agent-docs.config.yml` as `options.urlPathPattern`.
 
 ### Request behavior
 

--- a/src/checks/content-discoverability/llms-txt-directive-html.ts
+++ b/src/checks/content-discoverability/llms-txt-directive-html.ts
@@ -82,7 +82,7 @@ async function check(ctx: CheckContext): Promise<CheckResult> {
     const batchResults = await Promise.all(
       batch.map(async (url): Promise<DirectiveResult> => {
         try {
-          const htmlUrl = toHtmlUrl(url);
+          const htmlUrl = toHtmlUrl(url, ctx.options.urlPathPattern);
           const response = await ctx.http.fetch(htmlUrl);
           if (!response.ok) {
             return { url: htmlUrl, found: false, error: `HTTP ${response.status}` };

--- a/src/checks/content-discoverability/llms-txt-directive-md.ts
+++ b/src/checks/content-discoverability/llms-txt-directive-md.ts
@@ -58,7 +58,7 @@ async function fetchMarkdown(
   ctx: CheckContext,
   pageUrl: string,
 ): Promise<{ text: string; url: string } | null> {
-  const htmlUrl = toHtmlUrl(pageUrl);
+  const htmlUrl = toHtmlUrl(pageUrl, ctx.options.urlPathPattern);
   const mdCandidates = toMdUrls(htmlUrl);
 
   for (const mdUrl of mdCandidates) {

--- a/src/checks/markdown-availability/content-negotiation.ts
+++ b/src/checks/markdown-availability/content-negotiation.ts
@@ -45,7 +45,7 @@ async function check(ctx: CheckContext): Promise<CheckResult> {
         // Pre-request: normalize .md/.mdx URLs to their canonical HTML form (#33).
         // Testing content negotiation against a .md URL is meaningless because the
         // server already serves markdown at that path by definition.
-        const fetchUrl = isMdUrl(url) ? toHtmlUrl(url) : url;
+        const fetchUrl = isMdUrl(url) ? toHtmlUrl(url, ctx.options.urlPathPattern) : url;
         const testedUrl = fetchUrl !== url ? fetchUrl : undefined;
 
         try {

--- a/src/checks/observability/markdown-content-parity.ts
+++ b/src/checks/observability/markdown-content-parity.ts
@@ -625,7 +625,7 @@ async function check(ctx: CheckContext): Promise<CheckResult> {
       batch.map(async ({ url, markdownContent, markdownSource }): Promise<PageParityResult> => {
         try {
           // Fetch the HTML version of the page
-          const htmlUrl = toHtmlUrl(url);
+          const htmlUrl = toHtmlUrl(url, ctx.options.urlPathPattern);
           const page = await fetchPage(ctx, htmlUrl);
 
           if (page.status >= 400) {

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -3,7 +3,12 @@ import { normalizeUrl, runChecks } from '../../runner.js';
 import { formatText } from '../formatters/text.js';
 import { formatJson } from '../formatters/json.js';
 import { formatScorecard } from '../formatters/scorecard.js';
-import type { PageConfigEntry, RunnerOptions, SamplingStrategy } from '../../types.js';
+import type {
+  PageConfigEntry,
+  RunnerOptions,
+  SamplingStrategy,
+  UrlPathPattern,
+} from '../../types.js';
 import { findConfig, validatePages } from '../../helpers/config.js';
 import { validateRunnerOptions } from '../../validation.js';
 
@@ -30,6 +35,10 @@ export function registerCheckCommand(program: Command): void {
     .option(
       '--urls <urls>',
       'Comma-separated page URLs for curated scoring (implies --sampling curated)',
+    )
+    .option(
+      '--url-path-pattern <pattern>',
+      'How llms.txt .md links map to page URLs: clean (strip extension, default), html (replace with .html), or md (keep .md)',
     )
     .option('--doc-locale <code>', 'Preferred locale for URL discovery (e.g. en, fr, ja)')
     .option('--doc-version <version>', 'Preferred version for URL discovery (e.g. v3, 2.x, latest)')
@@ -187,6 +196,8 @@ export function registerCheckCommand(program: Command): void {
         process.stderr.write(`Running checks on ${target}...\n`);
       }
 
+      const urlPathPattern =
+        (opts.urlPathPattern as string | undefined) ?? config?.options?.urlPathPattern;
       const preferredLocale =
         (opts.docLocale as string | undefined) ?? config?.options?.preferredLocale;
       const preferredVersion =
@@ -274,6 +285,7 @@ export function registerCheckCommand(program: Command): void {
           pass: passThreshold,
           fail: failThreshold,
         },
+        ...(urlPathPattern && { urlPathPattern: urlPathPattern as UrlPathPattern }),
         ...(preferredLocale && { preferredLocale }),
         ...(preferredVersion && { preferredVersion }),
         ...(canonicalOrigin && { canonicalOrigin }),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import type { CheckOptions, SamplingStrategy, SizeThresholds } from './types.js';
+import type { CheckOptions, SamplingStrategy, SizeThresholds, UrlPathPattern } from './types.js';
 
 export const VALID_SAMPLING_STRATEGIES: readonly SamplingStrategy[] = [
   'random',
@@ -6,6 +6,8 @@ export const VALID_SAMPLING_STRATEGIES: readonly SamplingStrategy[] = [
   'curated',
   'none',
 ];
+
+export const VALID_URL_PATH_PATTERNS: readonly UrlPathPattern[] = ['clean', 'html', 'md'];
 
 export const DEFAULT_THRESHOLDS: SizeThresholds = {
   pass: 50_000,

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -3,7 +3,7 @@ import { dirname, resolve } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import type { AgentDocsConfig, PageConfigEntry } from '../types.js';
 import { validateNumber } from '../validation.js';
-import { VALID_SAMPLING_STRATEGIES } from '../constants.js';
+import { VALID_SAMPLING_STRATEGIES, VALID_URL_PATH_PATTERNS } from '../constants.js';
 
 const CONFIG_FILENAMES = ['agent-docs.config.yml', 'agent-docs.config.yaml'];
 
@@ -86,6 +86,16 @@ function validateOptions(options: Record<string, unknown>, source: string): void
   ) {
     throw new Error(
       `${source}: options.samplingStrategy must be one of: ${VALID_SAMPLING_STRATEGIES.join(', ')}`,
+    );
+  }
+  if (
+    options.urlPathPattern != null &&
+    !VALID_URL_PATH_PATTERNS.includes(
+      options.urlPathPattern as string as (typeof VALID_URL_PATH_PATTERNS)[number],
+    )
+  ) {
+    throw new Error(
+      `${source}: options.urlPathPattern must be one of: ${VALID_URL_PATH_PATTERNS.join(', ')}`,
     );
   }
   for (const [field, constraints] of NUMERIC_OPTION_RULES) {

--- a/src/helpers/get-page-urls.ts
+++ b/src/helpers/get-page-urls.ts
@@ -4,7 +4,7 @@ import { getLlmsTxtFilesForAnalysis, selectCanonicalLlmsTxt } from './llms-txt.j
 import { isNonPageUrl, isMdUrl, toHtmlUrl } from './to-md-urls.js';
 import { isSameSite } from './host-equivalence.js';
 import { isLocaleSegment, hasStructuralDuplication } from './locale-codes.js';
-import type { CheckContext, DiscoveredFile } from '../types.js';
+import type { CheckContext, DiscoveredFile, UrlPathPattern } from '../types.js';
 
 /**
  * Extract `<loc>` URLs from a sitemap XML string.
@@ -54,7 +54,7 @@ export async function getUrlsFromCachedLlmsTxtWithOriginals(
   const existsResult = ctx.previousResults.get('llms-txt-exists');
   const discovered = getLlmsTxtFilesForAnalysis(existsResult);
 
-  const entries = extractLinksFromLlmsTxtFiles(discovered);
+  const entries = extractLinksFromLlmsTxtFiles(discovered, ctx.options.urlPathPattern);
   const result = await walkAggregateLinksWithOriginals(ctx, entries);
   return {
     pageUrls: result.pageUrls.map((p) => p.url),
@@ -68,7 +68,7 @@ export async function getUrlsFromCachedLlmsTxtWithOmitted(
   const existsResult = ctx.previousResults.get('llms-txt-exists');
   const discovered = getLlmsTxtFilesForAnalysis(existsResult);
 
-  const entries = extractLinksFromLlmsTxtFiles(discovered);
+  const entries = extractLinksFromLlmsTxtFiles(discovered, ctx.options.urlPathPattern);
   const result = await walkAggregateLinksWithOriginals(ctx, entries);
   return {
     pageUrls: result.pageUrls.map((p) => p.url),
@@ -93,9 +93,12 @@ function collectOriginalMdUrls(pages: DiscoveredPageUrl[]): Record<string, strin
  * returned alongside as `originalMdUrl` so that markdown-availability checks
  * can still test the URL the site explicitly published (issue #77).
  */
-function normalizePageUrl(url: string): { url: string; originalMdUrl?: string } {
+function normalizePageUrl(
+  url: string,
+  pattern?: UrlPathPattern,
+): { url: string; originalMdUrl?: string } {
   if (isMdUrl(url)) {
-    return { url: toHtmlUrl(url), originalMdUrl: url };
+    return { url: toHtmlUrl(url, pattern), originalMdUrl: url };
   }
   return { url };
 }
@@ -105,14 +108,17 @@ interface DiscoveredPageUrl {
   originalMdUrl?: string;
 }
 
-function extractLinksFromLlmsTxtFiles(files: DiscoveredFile[]): DiscoveredPageUrl[] {
+function extractLinksFromLlmsTxtFiles(
+  files: DiscoveredFile[],
+  pattern?: UrlPathPattern,
+): DiscoveredPageUrl[] {
   // Map normalized URL → originalMdUrl. A given page may appear in llms.txt
   // both as `/page.md` and `/page` (HTML); we keep the .md form so downstream
   // markdown checks have a known-good URL to test.
   const seen = new Map<string, string | undefined>();
 
   function record(rawUrl: string) {
-    const { url, originalMdUrl } = normalizePageUrl(rawUrl);
+    const { url, originalMdUrl } = normalizePageUrl(rawUrl, pattern);
     const existing = seen.get(url);
     if (existing === undefined && originalMdUrl) {
       seen.set(url, originalMdUrl);
@@ -205,7 +211,7 @@ async function walkAggregateLinksWithOriginals(
         status: response.status,
         redirected: response.redirected,
       };
-      const subEntries = extractLinksFromLlmsTxtFiles([subFile]);
+      const subEntries = extractLinksFromLlmsTxtFiles([subFile], ctx.options.urlPathPattern);
 
       for (const subEntry of subEntries) {
         try {
@@ -275,7 +281,7 @@ async function fetchLlmsTxtUrls(
 
   const canonical = selectCanonicalLlmsTxt(discovered, ctx.baseUrl);
   const filesForAnalysis = canonical ? [canonical] : [];
-  const entries = extractLinksFromLlmsTxtFiles(filesForAnalysis);
+  const entries = extractLinksFromLlmsTxtFiles(filesForAnalysis, ctx.options.urlPathPattern);
   const result = await walkAggregateLinksWithOriginals(ctx, entries);
   return {
     pageUrls: result.pageUrls.map((p) => p.url),

--- a/src/helpers/to-md-urls.ts
+++ b/src/helpers/to-md-urls.ts
@@ -1,4 +1,5 @@
 import { isSameSite } from './host-equivalence.js';
+import type { UrlPathPattern } from '../types.js';
 
 /**
  * Returns true if the two URLs have different hosts (i.e. a cross-host redirect).
@@ -35,16 +36,32 @@ export function isNonPageUrl(url: string): boolean {
 }
 
 /**
- * Convert a .md or .mdx URL back to its canonical HTML equivalent.
- * Inverts the transforms from toMdUrls():
- *   /docs/guide.md       -> /docs/guide
- *   /docs/guide/index.md -> /docs/guide/
- *   /docs/guide.mdx      -> /docs/guide
+ * Convert a .md or .mdx URL to its canonical page URL equivalent, according
+ * to the site's URL path pattern:
+ * - 'clean' (default) strips the extension, inverting the transforms from
+ *   toMdUrls():
+ *     /docs/guide.md       -> /docs/guide
+ *     /docs/guide/index.md -> /docs/guide/
+ *     /docs/guide.mdx      -> /docs/guide
+ * - 'html' replaces the extension for sites that serve real filenames:
+ *     /docs/guide.md       -> /docs/guide.html
+ * - 'md' keeps the .md URL as the canonical page URL.
  * If the URL doesn't end in .md/.mdx, return it unchanged.
  */
-export function toHtmlUrl(url: string): string {
+export function toHtmlUrl(url: string, pattern: UrlPathPattern = 'clean'): string {
+  if (pattern === 'md') return url;
   try {
     const parsed = new URL(url);
+    if (pattern === 'html') {
+      if (/\.mdx?$/i.test(parsed.pathname)) {
+        // Strip the markdown extension first so `.html.md` URLs don't
+        // become `.html.html`.
+        const stripped = parsed.pathname.replace(/\.mdx?$/i, '');
+        parsed.pathname = /\.html?$/i.test(stripped) ? stripped : stripped + '.html';
+        return parsed.toString();
+      }
+      return url;
+    }
     if (parsed.pathname.endsWith('/index.md') || parsed.pathname.endsWith('/index.mdx')) {
       parsed.pathname = parsed.pathname.replace(/\/index\.mdx?$/, '/');
       return parsed.toString();

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,16 @@ export interface CheckContext {
 
 export type SamplingStrategy = 'random' | 'deterministic' | 'curated' | 'none';
 
+/**
+ * How llms.txt `.md`/`.mdx` links map to the site's page URLs:
+ * - 'clean': strip the extension (`/guide.md` → `/guide`). Default.
+ * - 'html': replace the extension (`/guide.md` → `/guide.html`) for sites
+ *   that serve real filenames.
+ * - 'md': keep the `.md` URL as the canonical page URL for sites that serve
+ *   markdown files directly.
+ */
+export type UrlPathPattern = 'clean' | 'html' | 'md';
+
 export interface CuratedPageEntry {
   url: string;
   tag?: string;
@@ -78,6 +88,8 @@ export interface CheckOptions {
   samplingStrategy: SamplingStrategy;
   /** Size thresholds. */
   thresholds: SizeThresholds;
+  /** How llms.txt .md links map to page URLs. Default 'clean' (strip the extension). */
+  urlPathPattern?: UrlPathPattern;
   /** Preferred locale for URL discovery (e.g. 'en', 'fr', 'ja'). Overrides auto-detection from baseUrl. */
   preferredLocale?: string;
   /** Preferred version for URL discovery (e.g. 'v3', '2.x', 'latest'). Overrides auto-detection from baseUrl. */

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,5 +1,5 @@
-import type { RunnerOptions, SamplingStrategy } from './types.js';
-import { VALID_SAMPLING_STRATEGIES } from './constants.js';
+import type { RunnerOptions, SamplingStrategy, UrlPathPattern } from './types.js';
+import { VALID_SAMPLING_STRATEGIES, VALID_URL_PATH_PATTERNS } from './constants.js';
 import { getAllChecks } from './checks/registry.js';
 
 export interface ValidationIssue {
@@ -167,6 +167,17 @@ export function validateRunnerOptions(options: Partial<RunnerOptions>): Validati
     errors.push({
       field: 'samplingStrategy',
       message: `Invalid sampling strategy "${options.samplingStrategy}". Must be one of: ${VALID_SAMPLING_STRATEGIES.join(', ')}`,
+    });
+  }
+
+  // URL path pattern enum
+  if (
+    options.urlPathPattern !== undefined &&
+    !VALID_URL_PATH_PATTERNS.includes(options.urlPathPattern as UrlPathPattern)
+  ) {
+    errors.push({
+      field: 'urlPathPattern',
+      message: `Invalid URL path pattern "${options.urlPathPattern}". Must be one of: ${VALID_URL_PATH_PATTERNS.join(', ')}`,
     });
   }
 

--- a/test/unit/helpers/config.test.ts
+++ b/test/unit/helpers/config.test.ts
@@ -427,6 +427,27 @@ describe('findConfig', () => {
     expect(config?.options?.samplingStrategy).toBe('deterministic');
   });
 
+  it('throws on invalid urlPathPattern in config', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    await writeFile(
+      resolve(TMP_DIR, 'agent-docs.config.yml'),
+      ['url: https://example.com', 'options:', '  urlPathPattern: dotphp', ''].join('\n'),
+    );
+
+    await expect(findConfig(undefined, TMP_DIR)).rejects.toThrow('urlPathPattern');
+  });
+
+  it('accepts valid urlPathPattern in config', async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+    await writeFile(
+      resolve(TMP_DIR, 'agent-docs.config.yml'),
+      ['url: https://example.com', 'options:', '  urlPathPattern: html', ''].join('\n'),
+    );
+
+    const config = await findConfig(undefined, TMP_DIR);
+    expect(config?.options?.urlPathPattern).toBe('html');
+  });
+
   it('throws when checks is not a string array', async () => {
     await mkdir(TMP_DIR, { recursive: true });
     await writeFile(

--- a/test/unit/helpers/get-page-urls.test.ts
+++ b/test/unit/helpers/get-page-urls.test.ts
@@ -2414,6 +2414,55 @@ describe('originalMdUrls (issue #77)', () => {
     );
   });
 
+  it('maps .md links to .html page URLs with urlPathPattern "html" (issue #95)', async () => {
+    const ctx = createContext('http://test95a.local', { requestDelay: 0, urlPathPattern: 'html' });
+    const content = `# Docs
+> Summary
+## Links
+- [Auth](http://test95a.local/docs/auth.md): Auth
+`;
+    const discovered: DiscoveredFile[] = [
+      { url: 'http://test95a.local/llms.txt', content, status: 200, redirected: false },
+    ];
+    ctx.previousResults.set('llms-txt-exists', {
+      id: 'llms-txt-exists',
+      category: 'content-discoverability',
+      status: 'pass',
+      message: 'Found',
+      details: { discoveredFiles: discovered },
+    });
+    mockSitemapNotFound(server, 'http://test95a.local');
+
+    const result = await discoverAndSamplePages(ctx);
+    expect(result.urls).toContain('http://test95a.local/docs/auth.html');
+    expect(result.originalMdUrls!['http://test95a.local/docs/auth.html']).toBe(
+      'http://test95a.local/docs/auth.md',
+    );
+  });
+
+  it('keeps .md links as page URLs with urlPathPattern "md" (issue #95)', async () => {
+    const ctx = createContext('http://test95b.local', { requestDelay: 0, urlPathPattern: 'md' });
+    const content = `# Docs
+> Summary
+## Links
+- [Auth](http://test95b.local/docs/auth.md): Auth
+`;
+    const discovered: DiscoveredFile[] = [
+      { url: 'http://test95b.local/llms.txt', content, status: 200, redirected: false },
+    ];
+    ctx.previousResults.set('llms-txt-exists', {
+      id: 'llms-txt-exists',
+      category: 'content-discoverability',
+      status: 'pass',
+      message: 'Found',
+      details: { discoveredFiles: discovered },
+    });
+    mockSitemapNotFound(server, 'http://test95b.local');
+
+    const result = await discoverAndSamplePages(ctx);
+    expect(result.urls).toContain('http://test95b.local/docs/auth.md');
+  });
+
   it('does not populate originalMdUrls for sitemap-only discovery', async () => {
     const ctx = createContext('http://test77d.local', { requestDelay: 0 });
     ctx.previousResults.set('llms-txt-exists', {

--- a/test/unit/helpers/to-md-urls.test.ts
+++ b/test/unit/helpers/to-md-urls.test.ts
@@ -122,6 +122,52 @@ describe('toHtmlUrl', () => {
   it('returns malformed URLs unchanged', () => {
     expect(toHtmlUrl('not-a-url')).toBe('not-a-url');
   });
+
+  describe('html pattern', () => {
+    it('replaces .md with .html', () => {
+      expect(toHtmlUrl('https://example.com/docs/guide.md', 'html')).toBe(
+        'https://example.com/docs/guide.html',
+      );
+    });
+
+    it('replaces .mdx with .html', () => {
+      expect(toHtmlUrl('https://example.com/docs/guide.mdx', 'html')).toBe(
+        'https://example.com/docs/guide.html',
+      );
+    });
+
+    it('does not double the extension for .html.md URLs', () => {
+      expect(toHtmlUrl('https://example.com/docs/guide.html.md', 'html')).toBe(
+        'https://example.com/docs/guide.html',
+      );
+    });
+
+    it('converts index.md to index.html', () => {
+      expect(toHtmlUrl('https://example.com/docs/guide/index.md', 'html')).toBe(
+        'https://example.com/docs/guide/index.html',
+      );
+    });
+
+    it('returns non-.md URLs unchanged', () => {
+      expect(toHtmlUrl('https://example.com/docs/guide', 'html')).toBe(
+        'https://example.com/docs/guide',
+      );
+    });
+  });
+
+  describe('md pattern', () => {
+    it('keeps .md URLs as-is', () => {
+      expect(toHtmlUrl('https://example.com/docs/guide.md', 'md')).toBe(
+        'https://example.com/docs/guide.md',
+      );
+    });
+
+    it('keeps index.md URLs as-is', () => {
+      expect(toHtmlUrl('https://example.com/docs/guide/index.md', 'md')).toBe(
+        'https://example.com/docs/guide/index.md',
+      );
+    });
+  });
 });
 
 describe('isMdUrl', () => {

--- a/test/unit/validation.test.ts
+++ b/test/unit/validation.test.ts
@@ -272,6 +272,23 @@ describe('validateRunnerOptions', () => {
     }
   });
 
+  describe('enum: urlPathPattern', () => {
+    it('rejects invalid pattern', () => {
+      const result = validateRunnerOptions({
+        urlPathPattern: 'dotphp' as RunnerOptions['urlPathPattern'],
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].field).toBe('urlPathPattern');
+      expect(result.errors[0].message).toContain('clean');
+    });
+
+    for (const pattern of ['clean', 'html', 'md'] as const) {
+      it(`accepts "${pattern}"`, () => {
+        expect(validateRunnerOptions({ urlPathPattern: pattern }).valid).toBe(true);
+      });
+    }
+  });
+
   describe('constraint: curated requires pages', () => {
     it('errors for curated with no curatedPages', () => {
       const result = validateRunnerOptions({ samplingStrategy: 'curated' });


### PR DESCRIPTION
## Summary
- Adds a `urlPathPattern` option (`--url-path-pattern` CLI flag, `options.urlPathPattern` in config) controlling how llms.txt `.md` links map to the site's page URLs:
  - `clean` (default): strip the extension (`/guide.md` → `/guide`), the existing behavior
  - `html`: replace the extension (`/guide.md` → `/guide.html`) for sites that serve real filenames; `.html.md` links don't get doubled
  - `md`: keep the `.md` URL as the canonical page URL for sites that serve markdown directly
- Threads the pattern through llms.txt link normalization (`extractLinksFromLlmsTxtFiles`) and every check that converts `.md` URLs to page URLs (`llms-txt-directive-html`, `llms-txt-directive-md`, `content-negotiation`, `markdown-content-parity`)
- Validates the value in both runner options and config loading, and documents the flag in the CLI reference

Closes #95

## Test plan
- [x] Unit tests for `toHtmlUrl` under `html` and `md` patterns (including the `.html.md` non-doubling case)
- [x] Integration tests: llms.txt `.md` links resolve to `.html` page URLs / stay `.md` per pattern
- [x] Validation tests for runner options and config enum checks
- [x] `npm test` (1310 tests), `npm run lint`, prettier clean